### PR TITLE
Hotfix/Delete @Apioff in upload image

### DIFF
--- a/src/main/java/koreatech/in/controller/UploadController.java
+++ b/src/main/java/koreatech/in/controller/UploadController.java
@@ -28,7 +28,6 @@ public class UploadController {
     private UploadFileUtils uploadFileUtils;
 
     // 단일 이미지 업로드
-    @ApiOff
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
     @RequestMapping(value = "/upload/image", method = RequestMethod.POST)
     public @ResponseBody
@@ -42,7 +41,6 @@ public class UploadController {
     }
 
     // 다중 이미지 업로드
-    @ApiOff
     @ApiImplicitParams(
             @ApiImplicitParam(name = "mtfRequest", required = true, paramType = "form", dataType = "file")
     )


### PR DESCRIPTION
- Admin에서 `upload image`를 사용하여 @Apioff를 해제했습니다.
- [축소 API 목록](https://docs.google.com/spreadsheets/d/16TwVIrE0aMjf2YEf_-QeiXATYkujj9_gwcsxMw29wlk/edit#gid=0)을 갱신했습니다.