### PR TITLE
Hotfix/Delete @Apioff in upload market image

### DIFF
--- a/src/main/java/koreatech/in/controller/MarketPlaceController.java
+++ b/src/main/java/koreatech/in/controller/MarketPlaceController.java
@@ -145,7 +145,6 @@ public class MarketPlaceController {
         return new ResponseEntity<Map<String, Boolean>>(marketPlaceService.checkGrantEditItem(item_id.get("item_id")), HttpStatus.OK);
     }
 
-    @ApiOff
     @ApiImplicitParams(
             @ApiImplicitParam(name = "mtfRequest", required = true, paramType = "form", dataType = "file")
     )


### PR DESCRIPTION
- Admin에서 upload market image를 사용하여 @Apioff를 해제했습니다.
- [축소 API 목록](https://docs.google.com/spreadsheets/d/16TwVIrE0aMjf2YEf_-QeiXATYkujj9_gwcsxMw29wlk/edit#gid=0)을 갱신했습니다.