### PR TITLE
Feature/user server renewal

### DIFF
--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -8,6 +8,7 @@ import koreatech.in.annotation.AuthExcept;
 import koreatech.in.annotation.ParamValid;
 import koreatech.in.annotation.ValidationGroups;
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
+import koreatech.in.controller.user.dto.request.UserLoginRequest;
 import koreatech.in.domain.user.owner.Owner;
 import koreatech.in.domain.user.User;
 import koreatech.in.domain.user.student.Student;
@@ -171,8 +172,8 @@ public class UserController {
     @AuthExcept
     @ParamValid
     @RequestMapping(value = "/user/login", method = RequestMethod.POST)
-    public ResponseEntity login(@ApiParam(value = "(required: portal_account, password)", required = true) @RequestBody @Validated(ValidationGroups.Create.class) User user, BindingResult bindingResult) throws Exception {
-        return new ResponseEntity<Map<String, Object>>(userService.login(user), HttpStatus.OK);
+    public ResponseEntity login(@ApiParam(value = "(required: account, password)", required = true) @RequestBody @Validated(ValidationGroups.Create.class) UserLoginRequest request, BindingResult bindingResult) throws Exception {
+        return new ResponseEntity<Map<String, Object>>(userService.login(request.getAccount(), request.getPassword()), HttpStatus.OK);
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -11,6 +11,7 @@ import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
 import koreatech.in.controller.user.dto.request.UpdateUserRequest;
 import koreatech.in.controller.user.dto.request.UserLoginRequest;
 import koreatech.in.controller.user.dto.response.LoginResponse;
+import koreatech.in.controller.user.dto.response.StudentResponse;
 import koreatech.in.domain.user.owner.Owner;
 import koreatech.in.domain.user.User;
 import koreatech.in.domain.user.student.Student;
@@ -62,8 +63,10 @@ public class UserController {
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
     @RequestMapping(value = "/user/student/me", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity me() throws Exception {
-        return new ResponseEntity<Object>(userService.getStudent(), HttpStatus.OK);
+    ResponseEntity getStudent() throws Exception {
+        Student student = userService.getStudent();
+        StudentResponse response = new StudentResponse(student);
+        return new ResponseEntity<Object>(response, HttpStatus.OK);
     }
 
     @ParamValid

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -10,6 +10,7 @@ import koreatech.in.annotation.ValidationGroups;
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
 import koreatech.in.controller.user.dto.request.UpdateUserRequest;
 import koreatech.in.controller.user.dto.request.UserLoginRequest;
+import koreatech.in.controller.user.dto.response.LoginResponse;
 import koreatech.in.domain.user.owner.Owner;
 import koreatech.in.domain.user.User;
 import koreatech.in.domain.user.student.Student;
@@ -172,7 +173,7 @@ public class UserController {
     @ParamValid
     @RequestMapping(value = "/user/login", method = RequestMethod.POST)
     public ResponseEntity login(@ApiParam(value = "(required: account, password)", required = true) @RequestBody @Validated(ValidationGroups.Create.class) UserLoginRequest request, BindingResult bindingResult) throws Exception {
-        return new ResponseEntity<Map<String, Object>>(userService.login(request.getAccount(), request.getPassword()), HttpStatus.OK);
+        return new ResponseEntity<LoginResponse>(userService.login(request.getAccount(), request.getPassword()), HttpStatus.OK);
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -71,7 +71,7 @@ public class UserController {
 
     @ParamValid
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
-    @RequestMapping(value = "/user/me", method = RequestMethod.PUT)
+    @RequestMapping(value = "/user/student/me", method = RequestMethod.PUT)
     public @ResponseBody
     ResponseEntity updateStudentInformation(@ApiParam(value = "(optional: password, name, nickname, gender, identity, is_graduated, major, student_number, phone_number)", required = true) @RequestBody @Validated(ValidationGroups.Update.class) UpdateUserRequest request, BindingResult bindingResult) throws Exception {
         UpdateUserRequest clear = new UpdateUserRequest();

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -44,7 +44,7 @@ public class UserController {
 
     @AuthExcept
     @ParamValid
-    @ApiOperation(value = "(required: portal_account, password), (optional: name, nickname, gender, identity, is_graduated, major, student_number, phone_number)")
+    @ApiOperation(value = "(required: account, password), (optional: name, nickname, gender, identity, is_graduated, major, student_number, phone_number)")
     @RequestMapping(value = "/user/student/register", method = RequestMethod.POST)
     public @ResponseBody
     ResponseEntity studentRegister(

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -8,6 +8,7 @@ import koreatech.in.annotation.AuthExcept;
 import koreatech.in.annotation.ParamValid;
 import koreatech.in.annotation.ValidationGroups;
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
+import koreatech.in.controller.user.dto.request.UpdateUserRequest;
 import koreatech.in.controller.user.dto.request.UserLoginRequest;
 import koreatech.in.domain.user.owner.Owner;
 import koreatech.in.domain.user.User;
@@ -54,7 +55,7 @@ public class UserController {
 
         StudentRegisterRequest clear = new StudentRegisterRequest();
 
-        return new ResponseEntity<Map<String, Object>>(userService.StudentRegister((StudentRegisterRequest) StringXssChecker.xssCheck(request, clear), getHost(httpServletRequest)), HttpStatus.CREATED);
+        return new ResponseEntity<Map<String, Object>>(userService.StudentRegister(StringXssChecker.xssCheck(request, clear), getHost(httpServletRequest)), HttpStatus.CREATED);
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
@@ -68,11 +69,9 @@ public class UserController {
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
     @RequestMapping(value = "/user/me", method = RequestMethod.PUT)
     public @ResponseBody
-    ResponseEntity updateStudentInformation(@ApiParam(value = "(optional: password, name, nickname, gender, identity, is_graduated, major, student_number, phone_number)", required = true) @RequestBody @Validated(ValidationGroups.Update.class) Student student, BindingResult bindingResult) throws Exception {
-
-        Student clear = new Student();
-
-        return new ResponseEntity<>(userService.updateStudentInformation((Student) StringXssChecker.xssCheck(student, clear)), HttpStatus.CREATED);
+    ResponseEntity updateStudentInformation(@ApiParam(value = "(optional: password, name, nickname, gender, identity, is_graduated, major, student_number, phone_number)", required = true) @RequestBody @Validated(ValidationGroups.Update.class) UpdateUserRequest request, BindingResult bindingResult) throws Exception {
+        UpdateUserRequest clear = new UpdateUserRequest();
+        return new ResponseEntity<>(userService.updateStudentInformation(StringXssChecker.xssCheck(request, clear)), HttpStatus.CREATED);
     }
 
     @ParamValid
@@ -84,7 +83,7 @@ public class UserController {
 
         Owner clear = new Owner();
 
-        return new ResponseEntity<>(userService.updateOwnerInformation((Owner) StringXssChecker.xssCheck(owner, clear)), HttpStatus.CREATED);
+        return new ResponseEntity<>(userService.updateOwnerInformation(StringXssChecker.xssCheck(owner, clear)), HttpStatus.CREATED);
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -118,7 +118,7 @@ public class UserController {
     @ParamValid
     @RequestMapping(value = "/user/find/password", method = RequestMethod.POST)
     public @ResponseBody
-    ResponseEntity changePasswordConfig(@ApiParam(value = "(required: portal_account)", required = true) @RequestBody @Valid String account, BindingResult bindingResult, HttpServletRequest request) {
+    ResponseEntity changePasswordConfig(@ApiParam(value = "(required: account)", required = true) @RequestBody @Valid String account, BindingResult bindingResult, HttpServletRequest request) {
 
         // TODO: velocity template 에 인증 url에 들어갈 host를 넣기 위해 reigster에 url 데이터를 넘겼는데 추후 이 방법 없애고 plugin을 붙이는 방법으로 해결해보기
         // https://developer.atlassian.com/server/confluence/confluence-objects-accessible-from-velocity/

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -48,15 +48,6 @@ public class UserController {
             BindingResult bindingResult,
             HttpServletRequest httpServletRequest) throws Exception {
 
-        /*    // TODO: default로 셋팅할 수 있는 방법 알아보기
-        if (student.getIsGraduated() == null) {
-            student.setIsGraduated(false);
-        }
-
-        if (student.getIsAuthed() == null) {
-            student.setIsAuthed(false);
-        }*/
-
         // TODO: velocity template 에 인증 url에 들어갈 host를 넣기 위해 reigster에 url 데이터를 넘겼는데 추후 이 방법 없애고 plugin을 붙이는 방법으로 해결해보기
         // https://developer.atlassian.com/server/confluence/confluence-objects-accessible-from-velocity/
 

--- a/src/main/java/koreatech/in/controller/user/UserController.java
+++ b/src/main/java/koreatech/in/controller/user/UserController.java
@@ -38,9 +38,6 @@ public class UserController {
     @Autowired
     StudentMapper studentMapper;
 
-    @Autowired
-    UserMapper userMapper;
-
     @AuthExcept
     @ParamValid
     @ApiOperation(value = "(required: portal_account, password), (optional: name, nickname, gender, identity, is_graduated, major, student_number, phone_number)")

--- a/src/main/java/koreatech/in/controller/user/dto/UserResponse.java
+++ b/src/main/java/koreatech/in/controller/user/dto/UserResponse.java
@@ -1,0 +1,39 @@
+package koreatech.in.controller.user.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import koreatech.in.domain.user.User;
+import koreatech.in.domain.user.UserType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class UserResponse {
+    private Integer id;
+    private String account;
+    private String nickname;
+    private String name;
+    private String phoneNumber;
+    private String email;
+    private Integer gender;
+    private Boolean isAuth;
+    private UserType userType;
+    private Boolean isDeleted;
+
+    public UserResponse(User user) {
+        this.id = user.getId();
+        this.account = user.getAccount();
+        this.nickname = user.getNickname();
+        this.name = user.getName();
+        this.phoneNumber = user.getPhoneNumber();
+        this.email = user.getEmail();
+        this.gender = user.getGender();
+        this.isAuth = user.getIsAuthed();
+        this.userType = user.getUserType();
+        this.isDeleted = user.getIsDeleted();
+    }
+}

--- a/src/main/java/koreatech/in/controller/user/dto/request/StudentRegisterRequest.java
+++ b/src/main/java/koreatech/in/controller/user/dto/request/StudentRegisterRequest.java
@@ -41,9 +41,6 @@ public class StudentRegisterRequest {
     @ApiModelProperty(notes = "성별(남:0, 여:1)", example = "0")
     private Integer gender;
 
-    @ApiModelProperty(notes = "신원(0: 학생, 1: 대학원생, 2: 교수, 3: 교직원, 4: 졸업생)", example = "0")
-    private Integer identity;
-
     @ApiModelProperty(notes = "졸업 여부", example = "false")
     private Boolean isGraduated;
 
@@ -58,7 +55,7 @@ public class StudentRegisterRequest {
     @ApiModelProperty(notes = "휴대폰 번호", example = "010-0000-0000")
     private String phoneNumber;
 
-    public Student toEntity(){
+    public Student toEntity(Integer identity){
         if (isGraduated == null) {
             isGraduated = false;
         }
@@ -66,10 +63,8 @@ public class StudentRegisterRequest {
         return Student.builder()
                 .account(account)
                 .password(password)
-                .email(account+"@koreatech.ac.kr")
                 .name(name)
                 .nickname(nickname)
-                .anonymousNickname("익명_" + (System.currentTimeMillis()))
                 .gender(gender)
                 .identity(identity)
                 .isGraduated(isGraduated)

--- a/src/main/java/koreatech/in/controller/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/koreatech/in/controller/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,48 @@
+package koreatech.in.controller.user.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.annotations.ApiModelProperty;
+import koreatech.in.domain.user.student.Student;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class UpdateUserRequest {
+    @ApiModelProperty(notes = "비밀번호", example = "a0240120305812krlakdsflsa;1235")
+    private String password;
+    private String name;
+    @ApiModelProperty(notes = "성별(남:0, 여:1)", example = "0")
+    private Integer gender;
+    private Integer identity;
+    @ApiModelProperty(notes = "졸업 여부", example = "false")
+    private Boolean isGraduated;
+    @ApiModelProperty(notes = "기계공학부, 컴퓨터공학부, 메카트로닉스공학부, 전기전자통신공학부, 디자인건축공학부, 에너지신소재화학공학부, 산업경영학부", example = "컴퓨터공학부")
+    private String major;
+    @Size(max = 50, message = "학번은 50자 이내여야 합니다.")
+    @ApiModelProperty(notes = "학번", example = "2013136000")
+    private String studentNumber;
+    @Pattern(regexp = "^[0-9]{3}-[0-9]{3,4}-[0-9]{4}", message = "전화번호 형식이 올바르지 않습니다.")
+    @ApiModelProperty(notes = "휴대폰 번호", example = "010-0000-0000")
+    private String phoneNumber;
+
+    public Student toEntity(){
+        return Student.builder()
+                .password(password)
+                .name(name)
+                .gender(gender)
+                .identity(identity)
+                .isGraduated(isGraduated)
+                .major(major)
+                .studentNumber(studentNumber)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+}

--- a/src/main/java/koreatech/in/controller/user/dto/request/UserLoginRequest.java
+++ b/src/main/java/koreatech/in/controller/user/dto/request/UserLoginRequest.java
@@ -1,5 +1,7 @@
 package koreatech.in.controller.user.dto.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class UserLoginRequest {
     String account;
     String password;

--- a/src/main/java/koreatech/in/controller/user/dto/request/UserLoginRequest.java
+++ b/src/main/java/koreatech/in/controller/user/dto/request/UserLoginRequest.java
@@ -1,0 +1,13 @@
+package koreatech.in.controller.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserLoginRequest {
+    String account;
+    String password;
+}

--- a/src/main/java/koreatech/in/controller/user/dto/response/LoginResponse.java
+++ b/src/main/java/koreatech/in/controller/user/dto/response/LoginResponse.java
@@ -1,0 +1,24 @@
+package koreatech.in.controller.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import koreatech.in.controller.user.dto.UserResponse;
+import koreatech.in.domain.user.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class LoginResponse {
+    private UserResponse user;
+    private int ttl;
+    private String token;
+
+    public LoginResponse(User user, int ttl, String token) {
+        this.user = new UserResponse(user);
+        this.ttl = ttl;
+        this.token = token;
+    }
+}

--- a/src/main/java/koreatech/in/controller/user/dto/response/StudentResponse.java
+++ b/src/main/java/koreatech/in/controller/user/dto/response/StudentResponse.java
@@ -1,0 +1,32 @@
+package koreatech.in.controller.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import koreatech.in.controller.user.dto.UserResponse;
+import koreatech.in.domain.user.UserType;
+import koreatech.in.domain.user.student.Student;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class StudentResponse extends UserResponse {
+    private String anonymousNickname;
+    private String studentNumber;
+    private String major;
+    private Integer identity;
+    private Boolean isGraduated;
+    private String phoneNumber;
+
+    public StudentResponse(Student student) {
+        super(student);
+        this.anonymousNickname = student.getAnonymousNickname();
+        this.studentNumber = student.getStudentNumber();
+        this.major = student.getMajor();
+        this.identity = student.getIdentity();
+        this.isGraduated = student.getIsGraduated();
+        this.phoneNumber = student.getPhoneNumber();
+    }
+}

--- a/src/main/java/koreatech/in/domain/user/User.java
+++ b/src/main/java/koreatech/in/domain/user/User.java
@@ -56,7 +56,7 @@ public abstract class User implements UserDetails {
     protected Date createdAt;
     protected Date updatedAt;
 
-    protected User(String account, String password, String nickname, String name, String phoneNumber, String email, Integer gender) {
+    protected User(String account, String password, String nickname, String name, String phoneNumber, String email, Integer gender, UserType userType) {
         this.account = account;
         this.password = password;
         this.nickname = nickname;
@@ -64,6 +64,7 @@ public abstract class User implements UserDetails {
         this.phoneNumber = phoneNumber;
         this.email = email;
         this.gender = gender;
+        this.userType = userType;
     }
 
     @Override

--- a/src/main/java/koreatech/in/domain/user/User.java
+++ b/src/main/java/koreatech/in/domain/user/User.java
@@ -103,6 +103,12 @@ public abstract class User implements UserDetails {
         if (user.gender != null) {
             this.gender = user.gender;
         }
+        if(user.phoneNumber != null) {
+            this.phoneNumber = user.phoneNumber;
+        }
+        if(user.email != null) {
+            this.email = user.email;
+        }
         if (user.isAuthed != null) {
             this.isAuthed = user.isAuthed;
         }
@@ -141,5 +147,9 @@ public abstract class User implements UserDetails {
     public boolean isUserAuthed() { return isAuthed == null ? false : isAuthed; }
     public boolean isAuthTokenExpired(){
         return authExpiredAt == null ? false : authExpiredAt.getTime() - (new Date()).getTime() < 0;
+    }
+
+    public boolean equals(User user){
+        return user.id != null && this.id != null && this.id.equals(user.id);
     }
 }

--- a/src/main/java/koreatech/in/domain/user/User.java
+++ b/src/main/java/koreatech/in/domain/user/User.java
@@ -135,9 +135,10 @@ public abstract class User implements UserDetails {
     }
 
     public boolean isAwaitingEmailAuthenticate(){
-        return !isAuthed && !isAuthTokenExpired();
+        return isUserAuthed() && !isAuthTokenExpired();
     }
+    public boolean isUserAuthed() { return isAuthed == null ? false : isAuthed; }
     public boolean isAuthTokenExpired(){
-        return authExpiredAt.getTime() - (new Date()).getTime() < 0;
+        return authExpiredAt == null ? false : authExpiredAt.getTime() - (new Date()).getTime() < 0;
     }
 }

--- a/src/main/java/koreatech/in/domain/user/User.java
+++ b/src/main/java/koreatech/in/domain/user/User.java
@@ -135,7 +135,7 @@ public abstract class User implements UserDetails {
     }
 
     public boolean isAwaitingEmailAuthenticate(){
-        return isUserAuthed() && !isAuthTokenExpired();
+        return !isUserAuthed() && !isAuthTokenExpired();
     }
     public boolean isUserAuthed() { return isAuthed == null ? false : isAuthed; }
     public boolean isAuthTokenExpired(){

--- a/src/main/java/koreatech/in/domain/user/student/Student.java
+++ b/src/main/java/koreatech/in/domain/user/student/Student.java
@@ -77,7 +77,26 @@ public class Student extends User {
     }
 
     public void changeIdentity(Integer identity){
+        this.identity = identity;
+    }
 
+    public void update(Student student){
+        super.update(student);
+        if(student.anonymousNickname != null) {
+            this.anonymousNickname = student.getAnonymousNickname();
+        }
+        if(student.studentNumber != null) {
+            this.studentNumber = student.getStudentNumber();
+        }
+        if(student.major != null) {
+            this.major = student.major;
+        }
+        if(student.identity != null) {
+            this.identity = student.identity;
+        }
+        if(student.isGraduated != null) {
+            this.isGraduated = student.isGraduated;
+        }
     }
 
     @Builder

--- a/src/main/java/koreatech/in/domain/user/student/Student.java
+++ b/src/main/java/koreatech/in/domain/user/student/Student.java
@@ -3,6 +3,7 @@ package koreatech.in.domain.user.student;
 import io.swagger.annotations.ApiModelProperty;
 import koreatech.in.domain.user.User;
 import koreatech.in.domain.user.UserCode;
+import koreatech.in.domain.user.UserType;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -81,7 +82,7 @@ public class Student extends User {
 
     @Builder
     public Student(String account, String password, String email, String name, String nickname, String anonymousNickname, Integer gender, Integer identity, Boolean isGraduated, String major, String studentNumber, String phoneNumber){
-        super(account, password, nickname, name, phoneNumber, email, gender);
+        super(account, password, nickname, name, phoneNumber, email, gender, UserType.STUDENT);
         this.identity = identity;
         this.isGraduated = isGraduated;
         this.major = major;

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -15,7 +15,7 @@ public interface UserMapper{
     Integer isNicknameAlreadyUsed(String nickname);
     User getAuthedUserByAccount(String account);
     void updateUserIsAuthed(@Param("id")Integer id, @Param("isAuth")Boolean isAuth);
-    void updateResetTokenAndResetTokenExpiredTime(Integer id, String resetToken, Date resetTokenExpiredTime);
+    void updateResetTokenAndResetTokenExpiredTime(@Param("id") Integer id, @Param("resetToken") String resetToken, @Param("resetTokenExpiredTime") Date resetTokenExpiredTime);
     User getUserListForAdmin(@Param("cursor") int cursor, @Param("limit") int limit);
     Authority getAuthorityByUserIdForAdmin(@Param("id") int id);
     void insertUser(User user) throws SQLException;

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -24,6 +24,7 @@ public interface UserMapper{
     UserType getUserTypeById(@Param("id") int id);
     String getUserEmail(@Param("id") int id);
     void updateUser(User user);
+    void updateLastLoggedAt(@Param("id")int id, @Param("currentDate") Date currentDate);
     Integer getTotalCount();
     User getUserByAccount(String account);
     User getUserByNickName(String nickname);

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -14,7 +14,7 @@ public interface UserMapper{
     Integer isAccountAlreadyUsed(String account);
     Integer isNicknameAlreadyUsed(String nickname);
     User getAuthedUserByAccount(String account);
-    void updateUserIsAuthed(Integer id, Boolean isAuth);
+    void updateUserIsAuthed(@Param("id")Integer id, @Param("isAuth")Boolean isAuth);
     void updateResetTokenAndResetTokenExpiredTime(Integer id, String resetToken, Date resetTokenExpiredTime);
     User getUserListForAdmin(@Param("cursor") int cursor, @Param("limit") int limit);
     Authority getAuthorityByUserIdForAdmin(@Param("id") int id);

--- a/src/main/java/koreatech/in/service/user/UserService.java
+++ b/src/main/java/koreatech/in/service/user/UserService.java
@@ -3,6 +3,7 @@ package koreatech.in.service.user;
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
 import koreatech.in.controller.user.dto.request.UpdateUserRequest;
 import koreatech.in.controller.user.dto.request.UserLoginRequest;
+import koreatech.in.controller.user.dto.response.LoginResponse;
 import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.domain.user.owner.Owner;
@@ -32,7 +33,7 @@ public interface UserService {
 
     Map<String, Object> checkUserNickName(String nickname) throws Exception;
 
-    Map<String, Object> login(String account, String password) throws Exception;
+    LoginResponse login(String account, String password) throws Exception;
 
     Map<String, Object> logout();
 }

--- a/src/main/java/koreatech/in/service/user/UserService.java
+++ b/src/main/java/koreatech/in/service/user/UserService.java
@@ -4,6 +4,7 @@ import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
 import koreatech.in.controller.user.dto.request.UpdateUserRequest;
 import koreatech.in.controller.user.dto.request.UserLoginRequest;
 import koreatech.in.controller.user.dto.response.LoginResponse;
+import koreatech.in.controller.user.dto.response.StudentResponse;
 import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.domain.user.owner.Owner;
@@ -27,7 +28,7 @@ public interface UserService {
 
     Student getStudent() throws Exception;
 
-    Map<String,Object> updateStudentInformation(UpdateUserRequest request) throws Exception;
+    StudentResponse updateStudentInformation(UpdateUserRequest request) throws Exception;
 
     Map<String,Object> updateOwnerInformation(Owner owner) throws Exception;
 

--- a/src/main/java/koreatech/in/service/user/UserService.java
+++ b/src/main/java/koreatech/in/service/user/UserService.java
@@ -1,6 +1,7 @@
 package koreatech.in.service.user;
 
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
+import koreatech.in.controller.user.dto.request.UpdateUserRequest;
 import koreatech.in.controller.user.dto.request.UserLoginRequest;
 import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.Criteria;
@@ -25,7 +26,7 @@ public interface UserService {
 
     Student getStudent() throws Exception;
 
-    Map<String,Object> updateStudentInformation(Student student) throws Exception;
+    Map<String,Object> updateStudentInformation(UpdateUserRequest request) throws Exception;
 
     Map<String,Object> updateOwnerInformation(Owner owner) throws Exception;
 

--- a/src/main/java/koreatech/in/service/user/UserService.java
+++ b/src/main/java/koreatech/in/service/user/UserService.java
@@ -1,6 +1,7 @@
 package koreatech.in.service.user;
 
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
+import koreatech.in.controller.user.dto.request.UserLoginRequest;
 import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.domain.user.owner.Owner;
@@ -30,7 +31,7 @@ public interface UserService {
 
     Map<String, Object> checkUserNickName(String nickname) throws Exception;
 
-    Map<String, Object> login(User user) throws Exception;
+    Map<String, Object> login(String account, String password) throws Exception;
 
     Map<String, Object> logout();
 }

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -113,7 +113,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         User selectUser = userMapper.getUserByAccount(student.getAccount());
 
         if (selectUser != null) {
-            if (selectUser.getIsAuthed() || selectUser.isAwaitingEmailAuthenticate()) {
+            if (selectUser.isUserAuthed() || selectUser.isAwaitingEmailAuthenticate()) {
                 throw new ConflictException(new ErrorMessage("invalid authenticate", 0));
             }
         }

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -173,7 +173,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     @Override
     public Map<String, Object> changePasswordConfig(String account, String host) {
-        // TODO client 로부터 받을 때 validation 확인
         if (account == null) {
             throw new ValidationException(new ErrorMessage("account is required", 0));
         }

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -134,14 +134,18 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     private void checkMajorValidation(Student student) {
-        if (!student.isMajorValidated()) {
-            throw new PreconditionFailedException(new ErrorMessage("invalid dept code", 3));
+        if (student.getMajor() != null) {
+            if (!student.isMajorValidated()) {
+                throw new PreconditionFailedException(new ErrorMessage("invalid dept code", 3));
+            }
         }
     }
 
     private void checkStudentNumberValidation(Student student) {
-        if (!student.isStudentNumberValidated()) {
-            throw new PreconditionFailedException(new ErrorMessage("invalid student number", 2));
+        if (student.getStudentNumber() != null) {
+            if (!student.isStudentNumberValidated()) {
+                throw new PreconditionFailedException(new ErrorMessage("invalid student number", 2));
+            }
         }
     }
 

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -369,8 +369,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
         userMapper.updateLastLoggedAt(selectUser.getId(), new Date());
 
-        Map<String, Object> map = domainToMapWithExcept(selectUser, UserResponseType.getArray(), false);
-
         String loginToken = getLoginTokenFromRedis(selectUser);
         if (isTokenNotExistOrExpired(loginToken)) {
             loginToken = regenerateLoginTokenAndSetRedis(selectUser.getId());

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -348,7 +348,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     private void checkNicknameValidAndNotUsed(String nickname){
-        // TODO 클라이언트에서 넘어올때 확인하도록 수정
         if (StringUtils.isEmpty(nickname) || nickname.length() > 10)
             throw new PreconditionFailedException(new ErrorMessage("올바르지 않은 닉네임 형식입니다.", 0));
 

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -3,6 +3,7 @@ package koreatech.in.service.user;
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
 import koreatech.in.controller.user.dto.request.UpdateUserRequest;
 import koreatech.in.controller.user.dto.response.LoginResponse;
+import koreatech.in.controller.user.dto.response.StudentResponse;
 import koreatech.in.domain.ErrorMessage;
 import koreatech.in.domain.NotiSlack;
 import koreatech.in.domain.user.owner.Owner;
@@ -267,7 +268,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     @Override
     @Transactional
-    public Map<String, Object> updateStudentInformation(UpdateUserRequest request) throws Exception {
+    public StudentResponse updateStudentInformation(UpdateUserRequest request) throws Exception {
         Student student = request.toEntity();
 
         Student student_old = studentMapper.getStudentById(jwtValidator.validate().getId());
@@ -294,9 +295,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         userMapper.updateUser(student_old);
         studentMapper.updateStudent(student_old);
 
-        Map<String, Object> map = domainToMapWithExcept(student_old, UserResponseType.getArray(), false);
-
-        return map;
+        return new StudentResponse(student_old);
     }
 
     // TODO owner 정보 업데이트 

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -156,7 +156,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     public Boolean authenticate(String authToken) {
         User user = userMapper.getUserByAuthToken(authToken);
 
-        if (user == null || user.getIsAuthed() || isTokenExpired(user.getAuthExpiredAt())) {
+        if (user == null || user.isUserAuthed() || user.isAuthTokenExpired()) {
             return false;
         }
 

--- a/src/main/java/koreatech/in/service/user/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/user/UserServiceImpl.java
@@ -2,6 +2,7 @@ package koreatech.in.service.user;
 
 import koreatech.in.controller.user.dto.request.StudentRegisterRequest;
 import koreatech.in.controller.user.dto.request.UpdateUserRequest;
+import koreatech.in.controller.user.dto.response.LoginResponse;
 import koreatech.in.domain.ErrorMessage;
 import koreatech.in.domain.NotiSlack;
 import koreatech.in.domain.user.owner.Owner;
@@ -353,7 +354,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     @Override
-    public Map<String, Object> login(String account, String password) throws Exception {
+    public LoginResponse login(String account, String password) throws Exception {
         final User selectUser = userMapper.getAuthedUserByAccount(account);
         if(selectUser == null){
             throw new UnauthorizeException(new ErrorMessage("There is no such ID", 0));
@@ -372,13 +373,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
             loginToken = regenerateLoginTokenAndSetRedis(selectUser.getId());
         }
 
-        final String token = loginToken;
-
-        return new HashMap<String, Object>() {{
-            put("user", map);
-            put("token", token);
-            put("ttl", 4320);
-        }};
+        return new LoginResponse(selectUser, 4320, loginToken);
     }
 
     private boolean isTokenNotExistOrExpired(String getToken) {

--- a/src/main/java/koreatech/in/util/StringXssChecker.java
+++ b/src/main/java/koreatech/in/util/StringXssChecker.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 public class StringXssChecker {
-    public static Object xssCheck(Object vo, Object clear) throws Exception {
+    public static <T> T xssCheck(T vo, T clear) throws Exception {
         LucyXssFilter filter = XssSaxFilter.getInstance("lucy-xss-sax.xml");
 
         Map<String, Object> result = new HashMap<String, Object>();

--- a/src/main/resources/mapper/StudentMapper.xml
+++ b/src/main/resources/mapper/StudentMapper.xml
@@ -28,6 +28,18 @@
         );
     </insert>
 
+    <update id="updateStudent">
+        update koin.students
+        set
+            anonymous_nickname=#{anonymousNickname},
+            student_number=#{studentNumber},
+            major=#{major},
+            identity=#{identity},
+            is_graduated=#{isGraduated}
+        where
+            user_id=#{id}
+    </update>
+
     <delete id="deleteStudent">
         DELETE FROM koin.students WHERE user_id = #{id};
     </delete>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -135,7 +135,7 @@
         DELETE FROM koin.users WHERE ID = #{id};
     </delete>
 
-    <resultMap type="koreatech.in.domain.user.User" extends="userResultMap" id="userDiscriminator">
+    <resultMap type="koreatech.in.domain.user.student.Student" extends="userResultMap" id="userDiscriminator">
 
 <!--        <discriminator javaType="String" column="user_type">-->
 <!--            <case value="STUDENT" resultType="koreatech.in.domain.user.student.Student"/>-->
@@ -143,7 +143,7 @@
 <!--        </discriminator>-->
     </resultMap>
 
-    <resultMap id="userResultMap" type="koreatech.in.domain.user.User">
+    <resultMap id="userResultMap" type="koreatech.in.domain.user.student.Student">
         <id property="id" column="id"/>
         <result property="account" column="account"/>
         <result property="password" column="password"/>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -120,7 +120,6 @@
             NICKNAME = #{nickname},
             GENDER = #{gender},
             USER_TYPE = #{userType},
-            IS_GRADUATED = #{isGraduated},
             PHONE_NUMBER = #{phoneNumber},
             AUTH_TOKEN = #{authToken},
             AUTH_EXPIRED_AT = #{authExpiredAt},
@@ -129,6 +128,12 @@
             RESET_EXPIRED_AT = #{resetExpiredAt},
             PROFILE_IMAGE_URL = #{profileImageUrl}
         WHERE ID = #{id}
+    </update>
+
+    <update id="updateLastLoggedAt">
+        UPDATE koin.users
+        SET last_logged_at=#{currentDate}
+        WHERE id=#{id}
     </update>
 
     <delete id="deleteUser">

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -107,7 +107,7 @@
         update koin.users
         set
             reset_token=#{resetToken},
-            reset_token_expired_at=#{resetTokenExpiredTime}
+            reset_expired_at=#{resetTokenExpiredTime}
         where id=#{id}
     </update>
 


### PR DESCRIPTION
기존의 유저 관련 코드를 변경된 구조에 맞게 수정하였습니다.

DONE
- student로 별개로 수행해야 하는 api의 경우 분리했습니다.
- 이 경우 api에 /student 가 붙습니다
- user 공통 처리가 가능한 api의 경우는 변경된 구조에 맞게 수정했습니다. 
- 기존의 entity를 직접 주고받던 방식에서 dto를 주고받도록 변경했습니다
- user테이블의 경우 추상 클래스입니다. 따라서 user 테이블 조회 시 우선 하위 타입인 student로 조회하도록 하였습니다
- mybatis의 discriminator을 이용하여 상황에 맞게 반환하도록 수정하도록 노력중입니다 

TODO
- owner로 별개로 수행해야 하는 api의 경우 분리해야 합니다
- admin의 경우도 알맞게 수정해야 합니다