### PR TITLE
refactor: 시외버스 스케줄러 주기 변경

### DIFF
--- a/src/main/java/koreatech/in/domain/Bus/Bus.java
+++ b/src/main/java/koreatech/in/domain/Bus/Bus.java
@@ -28,10 +28,11 @@ public abstract class Bus {
     StringRedisUtilStr stringRedisUtilStr;
 
     String requestOpenAPI(String urlBuilder) throws IOException {
+        final int waitTime = 1000 * 3;
+
         URL url = new URL(urlBuilder);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setConnectTimeout(1000 * 5);
-        conn.setReadTimeout(1000 * 5);
+        conn.setConnectTimeout(waitTime);
         conn.setRequestMethod("GET");
 
         BufferedReader rd = new BufferedReader(new InputStreamReader(

--- a/src/main/java/koreatech/in/domain/Bus/CityBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/CityBus.java
@@ -105,7 +105,9 @@ public class CityBus extends Bus {
                     .filter(info -> IntStream.of(AVAILABLE_CITY_BUS).anyMatch(busNumber -> busNumber == info.getRouteno()))
                     .sorted()
                     .collect(Collectors.toList());
-            cacheBusArrivalInfo(nodeID, arrivalInfos);
+            if (!arrivalInfos.isEmpty()) {
+                cacheBusArrivalInfo(nodeID, arrivalInfos);
+            }
 
             return arrivalInfos;
         } catch (Exception e) {

--- a/src/main/java/koreatech/in/domain/Bus/IntercityBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/IntercityBus.java
@@ -144,7 +144,9 @@ public class IntercityBus extends Bus {
                     .stream()
                     .sorted()
                     .collect(Collectors.toList());
-            cacheBusArrivalInfo(departTerminal, arrivalTerminal, timetables);
+            if (!timetables.isEmpty()) {
+                cacheBusArrivalInfo(departTerminal, arrivalTerminal, timetables);
+            }
 
             return timetables;
         } catch (Exception e) {

--- a/src/main/java/koreatech/in/schedule/BusTago.java
+++ b/src/main/java/koreatech/in/schedule/BusTago.java
@@ -22,7 +22,7 @@ public class BusTago {
 
     // 하루에 한 번으로 지정하려했지만, 공공 데이터 API 호출 결과 00시에 바로 업데이트 되지 않음을 확인
     // 이전보다 더 잦게 스케줄링하도록 변경
-    @Scheduled(cron = "0 */5 * * * *") //@Scheduled(cron = "0 0 0 1/1 * *")
+    @Scheduled(cron = "0 */3 * * * *")
     public void handleIntercityBus() {
         intercityBus.cacheBusArrivalInfo();
     }


### PR DESCRIPTION
* 공공데이터 서버가 느려서 타임아웃이 자주 발생하고 있음. 따라서 타임아웃 대기 시간을 감소시키는 대신 요청 결과가 빈 값일 경우 캐싱하지 않도록 변경
* 정확한 결과를 위해 상황에 따른 튜닝 필요