### PR TITLE
fix: `DayOfWeek`의 인덱스가 월요일부터 시작하여 발생하던 문제 수정

### DIFF
--- a/src/main/java/koreatech/in/domain/Bus/IntercityBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/IntercityBus.java
@@ -76,7 +76,7 @@ public class IntercityBus extends Bus {
                     )
                     .nextRemainTime(
                             new BusRemainTime.RemainTime(null, (int) (nextDepartureTime.isBefore(nowDateTime) ?
-                                    ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime.plusDays(nowBusIndex == nextBusIndex ? 2 : 1)) : ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime)))
+                                    ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime.plusDays(nowBusIndex == nextBusIndex ? 2 : 1)) : ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime.plusDays(nowBusIndex == nextBusIndex ? 1 : 0))))
                     )
                     .build();
         } catch (NullPointerException e) {

--- a/src/main/java/koreatech/in/domain/Bus/SchoolBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/SchoolBus.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 
 public abstract class SchoolBus extends Bus {
 
-    private final String[] daysStr = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"};
+    private final String[] daysStr = {"MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"};
     private static final Type arrivalInfoType = new TypeToken<SchoolBusArrivalInfo>() {
     }.getType();
 
@@ -97,7 +97,7 @@ public abstract class SchoolBus extends Bus {
                     )
                     .nextRemainTime(
                             new BusRemainTime.RemainTime(null, (int) (nextDepartureTime.isBefore(nowDateTime) ?
-                                    ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime.plusDays(nowBusIndex == nextBusIndex ? 2 : 1)) : ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime)))
+                                    ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime.plusDays(nowBusIndex == nextBusIndex ? 2 : 1)) : ChronoUnit.SECONDS.between(nowDateTime, nextDepartureTime.plusDays(nowBusIndex == nextBusIndex ? 1 : 0))))
                     )
                     .build();
 


### PR DESCRIPTION
* 주의 시작을 일요일로 계산하였지만 공식 문서에 따르면 `DayOfWeek`가 월요일부터 시작하므로 변경
* 남은 버스 시간이 하나밖에 없을 경우 다음 날로 계산하지 않던 문제 수정 -> 이후 정책을 금일로만 계산하도록 제한할 것