### PR TITLE
refactor: 버스 검색 기한을 금일로 제한

### DIFF
--- a/src/main/java/koreatech/in/domain/Bus/CityBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/CityBus.java
@@ -160,7 +160,7 @@ public class CityBus extends Bus {
 
     @Override
     public SingleBusTime searchBusTime(String busType, String depart, String arrival, LocalDate date, LocalTime time) {
-        throw new UnsupportedOperationException();
+        return null;
     }
 
     private void cacheBusArrivalInfo(String nodeId, List<CityBusArrivalInfo> cityBusArrivalInfos) throws IOException {

--- a/src/main/java/koreatech/in/service/BusServiceImpl.java
+++ b/src/main/java/koreatech/in/service/BusServiceImpl.java
@@ -68,13 +68,8 @@ public class BusServiceImpl implements BusService {
             LocalTime localTime = LocalTime.parse(time);
             for (BusTypeEnum busTypeEnum : BusTypeEnum.values()) {
                 Bus bus = busTypeEnum.getBus();
-                SingleBusTime busTime;
-                try {
-                    busTime = bus.searchBusTime(busTypeEnum.name().toLowerCase(), depart, arrival, localDate, localTime);
-                    if (busTime == null) {
-                        continue;
-                    }
-                } catch (UnsupportedOperationException e) {
+                SingleBusTime busTime = bus.searchBusTime(busTypeEnum.name().toLowerCase(), depart, arrival, localDate, localTime);
+                if (busTime == null) {
                     continue;
                 }
                 result.add(busTime);


### PR DESCRIPTION
* 기존에는 금일 버스 운행이 종료되면 다음날 시간을 보여줬지만, 혼동을 줄 수 있고 표현하기 어렵기 때문에 제한하였음.
* 추후 시내버스 시간표 검색이 확장될 경우를 위하여 `UnsupportedOperationException` 제거