### PR TITLE
BugFix: User에서 Owner로 변환시의 ClassCastException 에러 수정

### DIFF
--- a/src/main/java/koreatech/in/domain/User/Owner.java
+++ b/src/main/java/koreatech/in/domain/User/Owner.java
@@ -13,6 +13,17 @@ public class Owner extends User {
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
+    public void update(User user) {
+        super.update(user);
+
+        if (user instanceof Owner) {
+            Owner owner = (Owner) user;
+            if (owner.email != null) {
+                this.email = owner.email;
+            }
+        }
+    }
+
     public String getEmail() {
         return email;
     }

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -176,7 +176,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         }
 
         if (selectUser.getIdentity() == UserCode.UserIdentity.OWNER.getIdentityType()) {
-            Owner owner = (Owner) selectUser;
+            Owner owner = new Owner();
             owner.update(user);
             userMapper.updateUser(owner);
             userMapper.updateOwner(owner);


### PR DESCRIPTION
- User 객체에서 자식 객체인 Owner 객체로 변환시 `ClassCastException`이 발생하는 에러였습니다.
- 변환 전에 `instanceof` 연산자로 타입 변환이 가능한지 먼저 체크하도록 수정하였습니다.