### PR TITLE
BugFix: 학번으로부터 전공 추출시의 NullPointException 에러 수정

### DIFF
--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -172,7 +172,8 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         }
 
         // 학번으로부터 전공 추출
-        user.setMajor(UserCode.extractMajorFromStudentNumber(user.getStudent_number()));
+        if(user.getStudent_number() != null && UserCode.isValidatedStudentNumber(user.getIdentity(), user.getStudent_number()))
+            user.setMajor(UserCode.extractMajorFromStudentNumber(user.getStudent_number()));
 
         // 학과 유효성 체크
         if (user.getMajor() != null && !UserCode.isValidatedDeptNumber(user.getMajor())) {


### PR DESCRIPTION
- 학번이 없는 경우 학번으로부터 전공 추출 과정(`UserCode.extractMajorFromStudentNumber()`의 `String deptCode = studentNumber.substring(5, 7);`)에서 NPE 발생
- 학번이 있고, 유효한 경우에만 **학번으로부터 전공 추출**`UserCode.extractMajorFromStudentNumber()` 을 진행하도록 수정