### PR TITLE
Task: 회원 탈퇴 API 리팩토링

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -122,7 +122,7 @@ public class UserController {
     })
     @RequestMapping(value = "/user", method = RequestMethod.DELETE)
     public @ResponseBody
-    ResponseEntity<EmptyResponse> withdraw() throws Exception {
+    ResponseEntity<EmptyResponse> withdraw() {
         userService.withdraw();
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -116,9 +116,9 @@ public class UserController {
 
     @ApiOperation(value = "탈퇴", authorizations = {@Authorization("Authorization")})
     @ApiResponses({
-            @ApiResponse(code = 401, message = "잘못된 접근일 때 (code: 100001) \n\n" +
-                                               "토큰의 유효시간이 만료되었을 때 (code: 100004) \n\n" +
-                                               "토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class)
+            @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n\n" +
+                                               "- 토큰의 유효시간이 만료되었을 때 (code: 100004) \n\n" +
+                                               "- 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class)
     })
     @RequestMapping(value = "/user", method = RequestMethod.DELETE)
     public @ResponseBody

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -113,12 +113,12 @@ public class UserController {
         return new ResponseEntity<>(userService.updateOwnerInformation(StringXssChecker.xssCheck(owner, clear)), HttpStatus.CREATED);
     }
 
-    @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
+    @ApiOperation(value = "", authorizations = {@Authorization("Authorization")})
     @RequestMapping(value = "/user", method = RequestMethod.DELETE)
-    public @ResponseBody ResponseEntity withdraw() throws Exception {
-
-        // TODO soft delete 방식으로 변경? yes.
-        return new ResponseEntity<Map<String, Object>>(userService.withdraw(), HttpStatus.OK);
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> withdraw() throws Exception {
+        userService.withdraw();
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @AuthExcept

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -113,7 +113,13 @@ public class UserController {
         return new ResponseEntity<>(userService.updateOwnerInformation(StringXssChecker.xssCheck(owner, clear)), HttpStatus.CREATED);
     }
 
-    @ApiOperation(value = "", authorizations = {@Authorization("Authorization")})
+
+    @ApiOperation(value = "탈퇴", authorizations = {@Authorization("Authorization")})
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "잘못된 접근일 때 (code: 100001) \n\n" +
+                                               "토큰의 유효시간이 만료되었을 때 (code: 100004) \n\n" +
+                                               "토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class)
+    })
     @RequestMapping(value = "/user", method = RequestMethod.DELETE)
     public @ResponseBody
     ResponseEntity<EmptyResponse> withdraw() throws Exception {

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -114,7 +114,7 @@ public class UserController {
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
-    @RequestMapping(value = "/user/me", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/user", method = RequestMethod.DELETE)
     public @ResponseBody ResponseEntity withdraw() throws Exception {
 
         // TODO soft delete 방식으로 변경? yes.

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -14,7 +14,7 @@ public interface UserMapper {
     User getAuthedUserById(@Param("id") Integer id);
     User getAuthedUserByAccount(@Param("account") String account);
     void updateLastLoggedAt(@Param("id") Integer id, @Param("currentDate") Date currentDate);
-
+    void deleteUser(@Param("id") Integer id, @Param("isHard") boolean isHard);
 
 
     Integer isAccountAlreadyUsed(String account);
@@ -27,7 +27,6 @@ public interface UserMapper {
     @Select("SELECT * FROM koin.admins WHERE USER_ID = #{id}")
     Authority getAuthorityByUserIdForAdmin(@Param("id") int id);
     void insertUser(User user) throws SQLException;
-    void deleteUser(@Param("id") int id);
     User getUserById(@Param("id") int id);
     UserType getUserTypeById(@Param("id") int id);
     String getUserEmail(@Param("id") int id);

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -14,7 +14,7 @@ public interface UserMapper {
     User getAuthedUserById(@Param("id") Integer id);
     User getAuthedUserByAccount(@Param("account") String account);
     void updateLastLoggedAt(@Param("id") Integer id, @Param("currentDate") Date currentDate);
-    void deleteUser(@Param("id") Integer id, @Param("isHard") boolean isHard);
+    void deleteUserLogicallyById(@Param("id") Integer id);
 
 
     Integer isAccountAlreadyUsed(String account);

--- a/src/main/java/koreatech/in/service/UserService.java
+++ b/src/main/java/koreatech/in/service/UserService.java
@@ -25,7 +25,7 @@ public interface UserService {
 
     Boolean changePasswordAuthenticate(String password, String resetToken);
 
-    Map<String, Object> withdraw() throws Exception;
+    void withdraw() throws Exception;
 
     Student getStudent() throws Exception;
 

--- a/src/main/java/koreatech/in/service/UserService.java
+++ b/src/main/java/koreatech/in/service/UserService.java
@@ -25,7 +25,7 @@ public interface UserService {
 
     Boolean changePasswordAuthenticate(String password, String resetToken);
 
-    void withdraw() throws Exception;
+    void withdraw();
 
     Student getStudent() throws Exception;
 

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -297,7 +297,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     public void withdraw() {
         User user = jwtValidator.validate();
 
-        userMapper.deleteUser(user.getId(), false);
+        userMapper.deleteUserLogicallyById(user.getId());
         deleteAccessTokenFromRedis(user.getId());
 
         slackNotiSender.noticeWithdraw(NotiSlack.builder()

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -298,12 +298,16 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         User user = jwtValidator.validate();
 
         userMapper.deleteUser(user.getId(), false);
-        stringRedisUtilStr.deleteData(redisLoginTokenKeyPrefix + user.getId().toString());
+        deleteAccessTokenFromRedis(user.getId());
 
         slackNotiSender.noticeWithdraw(NotiSlack.builder()
                 .color("good")
                 .text(user.getAccount() + "님이 탈퇴하셨습니다.")
                 .build());
+    }
+
+    private void deleteAccessTokenFromRedis(Integer userId) {
+        stringRedisUtilStr.deleteData(redisLoginTokenKeyPrefix + userId.toString());
     }
 
 

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -296,7 +296,8 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     @Transactional
     public void withdraw() throws Exception {
         User user = jwtValidator.validate();
-        userMapper.deleteUser(user.getId());
+
+        userMapper.deleteUser(user.getId(), false);
         stringRedisUtilStr.deleteData(redisLoginTokenKeyPrefix + user.getId().toString());
 
         slackNotiSender.noticeWithdraw(NotiSlack.builder()

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -294,7 +294,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     @Override
     @Transactional
-    public void withdraw() throws Exception {
+    public void withdraw() {
         User user = jwtValidator.validate();
 
         userMapper.deleteUser(user.getId(), false);

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -294,7 +294,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     @Override
     @Transactional
-    public Map<String, Object> withdraw() throws Exception {
+    public void withdraw() throws Exception {
         User user = jwtValidator.validate();
         userMapper.deleteUser(user.getId());
         stringRedisUtilStr.deleteData(redisLoginTokenKeyPrefix + user.getId().toString());
@@ -303,10 +303,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
                 .color("good")
                 .text(user.getAccount() + "님이 탈퇴하셨습니다.")
                 .build());
-
-        return new HashMap<String, Object>() {{
-            put("success", true);
-        }};
     }
 
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -228,7 +228,7 @@ public class AdminUserServiceImpl implements AdminUserService {
         } else {
             ownerMapper.deleteOwner(id);
         }
-        userMapper.deleteUser(id);
+        userMapper.deleteUser(id, true);
 
         return new HashMap<String, Object>() {{
             put("success", "delete student");

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -228,7 +228,7 @@ public class AdminUserServiceImpl implements AdminUserService {
         } else {
             ownerMapper.deleteOwner(id);
         }
-        userMapper.deleteUser(id, true);
+        userMapper.deleteUserLogicallyById(id);
 
         return new HashMap<String, Object>() {{
             put("success", "delete student");

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -216,19 +216,10 @@
             AND `is_deleted` = 0
     </update>
 
-    <delete id="deleteUser">
-        <choose>
-            <when test="isHard">
-                DELETE
-                FROM `koin`.`users`
-                WHERE `id` = #{id};
-            </when>
-            <otherwise>
-                UPDATE `koin`.`users`
-                SET `is_deleted` = 1
-                WHERE `id` = #{id}
-            </otherwise>
-        </choose>
+    <delete id="deleteUserLogicallyById">
+        UPDATE `koin`.`users`
+        SET `is_deleted` = 1
+        WHERE `id` = #{id}
     </delete>
 
     <select id="getUserById" resultMap="UserDiscriminator">

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -216,6 +216,21 @@
             AND `is_deleted` = 0
     </update>
 
+    <delete id="deleteUser">
+        <choose>
+            <when test="isHard">
+                DELETE
+                FROM `koin`.`users`
+                WHERE `id` = #{id};
+            </when>
+            <otherwise>
+                UPDATE `koin`.`users`
+                SET `is_deleted` = 1
+                WHERE `id` = #{id}
+            </otherwise>
+        </choose>
+    </delete>
+
     <select id="getUserById" resultMap="UserDiscriminator">
         SELECT * FROM koin.users WHERE ID = #{id};
     </select>
@@ -337,8 +352,4 @@
             PROFILE_IMAGE_URL = #{profileImageUrl}
         WHERE ID = #{id}
     </update>
-
-    <delete id="deleteUser">
-        DELETE FROM koin.users WHERE ID = #{id};
-    </delete>
 </mapper>


### PR DESCRIPTION
- URI를 `/user/me`에서 `/user`로 변경
- 코드 formatting
- 새 컨벤션 적용
- deleteUser() 호출시 soft delete 또는 hard delete 여부를 선택할 수 있게 변경
- Redis에서 access token 지우는 로직 메소드로 분리
- Swagger 문서화

참고
- 첫 task 브랜치 PR   