### PR TITLE
Task: 닉네임 중복 체크 API 리팩토링

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import javax.validation.constraints.Size;
 import java.util.Map;
 
 @Api(tags = "(Normal) User", description = "회원")
@@ -129,9 +130,10 @@ public class UserController {
 
     @AuthExcept
     @RequestMapping(value = "/user/check/nickname/{nickname}", method = RequestMethod.GET)
-    public @ResponseBody ResponseEntity checkUserNickName(@PathVariable(value = "nickname") String nickname) throws Exception {
-
-        return new ResponseEntity<Map<String, Object>>(userService.checkUserNickName(nickname), HttpStatus.OK);
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> checkUserNickName(@PathVariable("nickname") String nickname) throws Exception {
+        userService.checkUserNickName(nickname);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @AuthExcept

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -128,10 +128,19 @@ public class UserController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @ApiOperation(value = "닉네임 중복 체크", notes = "닉네임 중복시 http status 409, 중복이 아닐시 http status 200을 응답합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 409, message = "- 닉네임이 중복될 때 (code: 101002)", response = ExceptionResponse.class),
+            @ApiResponse(code = 422, message = "- nickname의 제약 조건을 위반하였을 때 (code: 100000)", response = ExceptionResponse.class)
+    })
     @AuthExcept
     @RequestMapping(value = "/user/check/nickname/{nickname}", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity<EmptyResponse> checkUserNickName(@PathVariable("nickname") String nickname) throws Exception {
+    ResponseEntity<EmptyResponse> checkUserNickName(
+            @ApiParam(value = "닉네임 \n " +
+                              "- not null \n " +
+                              "- 1자 이상 10자 이하 \n " +
+                              "- 공백 문자로만 이루어져있으면 안됨", required = true) @PathVariable("nickname") String nickname) throws Exception {
         userService.checkUserNickName(nickname);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/koreatech/in/domain/User/User.java
+++ b/src/main/java/koreatech/in/domain/User/User.java
@@ -101,6 +101,21 @@ public abstract class User {
         return this.authority != null;
     }
 
+    public boolean isEmailAuthenticationCompleted() {
+        return this.is_authed.equals(true);
+    }
+
+    public boolean isAuthTokenExpired() {
+        return auth_expired_at != null && (auth_expired_at.getTime() < (new Date()).getTime());
+    }
+
+    public boolean isAwaitingEmailAuthentication() {
+        return !isEmailAuthenticationCompleted()
+                && this.auth_token != null
+                && this.auth_expired_at != null
+                && !isAuthTokenExpired();
+    }
+
     public void changeAuthTokenAndExpiredAt(String authToken, Date authExpiredAt){
         this.auth_token = authToken;
         this.auth_expired_at = authExpiredAt;
@@ -110,13 +125,7 @@ public abstract class User {
         this.password = password;
     }
 
-    public boolean isAwaitingEmailAuthenticate(){
-        return !isUserAuthed() && !isAuthTokenExpired();
-    }
     public boolean isUserAuthed() { return is_authed == null ? false : is_authed; }
-    public boolean isAuthTokenExpired(){
-        return auth_expired_at == null ? false : auth_expired_at.getTime() - (new Date()).getTime() < 0;
-    }
 
     public boolean equals(User user){
         return user.id != null && this.id != null && this.id.equals(user.id);

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -16,6 +16,7 @@ public enum ExceptionInformation {
     // ======= 코인 회원 (학생, 사장님) =======
     USER_NOT_FOUND("회원이 존재하지 않습니다.", 101000, HttpStatus.UNAUTHORIZED),
     PASSWORD_DIFFERENT("비밀번호가 일치하지 않습니다.", 101001, HttpStatus.UNAUTHORIZED),
+    NICKNAME_DUPLICATE("이미 존재하는 닉네임입니다.", 101002, HttpStatus.CONFLICT),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -15,6 +15,7 @@ public interface UserMapper {
     User getAuthedUserByAccount(@Param("account") String account);
     void updateLastLoggedAt(@Param("id") Integer id, @Param("currentDate") Date currentDate);
     void deleteUserLogicallyById(@Param("id") Integer id);
+    User getUserByNickname(@Param("nickname") String nickname);
 
 
     Integer isAccountAlreadyUsed(String account);
@@ -33,7 +34,6 @@ public interface UserMapper {
     void updateUser(User user);
     Integer getTotalCount();
     User getUserByAccount(String account);
-    User getUserByNickName(String nickname);
     User getUserByAuthToken(String authToken);
     User getUserByResetToken(String resetToken);
 

--- a/src/main/java/koreatech/in/service/UserService.java
+++ b/src/main/java/koreatech/in/service/UserService.java
@@ -33,5 +33,5 @@ public interface UserService {
 
     Map<String,Object> updateOwnerInformation(Owner owner) throws Exception;
 
-    Map<String, Object> checkUserNickName(String nickname) throws Exception;
+    void checkUserNickName(String nickname);
 }

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -380,6 +380,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void checkUserNickName(String nickname) {
         checkNicknameValid(nickname);
         checkNicknameDuplicated(nickname);

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -187,7 +187,7 @@ public class AdminUserServiceImpl implements AdminUserService {
 
         // 닉네임 중복 체크
         if (student.getNickname() != null) {
-            User selectUser2 = userMapper.getUserByNickName(student.getNickname());
+            User selectUser2 = userMapper.getUserByNickname(student.getNickname());
             if (selectUser2 != null && !selectUser.getId().equals(selectUser2.getId())) {
                 throw new ConflictException(new ErrorMessage("nickname duplicate", 1));
             }

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -222,6 +222,78 @@
         WHERE `id` = #{id}
     </delete>
 
+    <select id="getUserByNickname" parameterType="string" resultMap="UserDiscriminator">
+        SELECT
+            `t1`.`id` AS `users.id`,
+            `t1`.`account` AS `users.account`,
+            `t1`.`password` AS `users.password`,
+            `t1`.`nickname` AS `users.nickname`,
+            `t1`.`name` AS `users.name`,
+            `t1`.`phone_number` AS `users.phone_number`,
+            `t1`.`user_type` AS `users.user_type`,
+            `t1`.`email` AS `users.email`,
+            `t1`.`gender` AS `users.gender`,
+            `t1`.`is_authed` AS `users.is_authed`,
+            `t1`.`last_logged_at` AS `users.last_logged_at`,
+            `t1`.`profile_image_url` AS `users.profile_image_url`,
+            `t1`.`auth_token` AS `users.auth_token`,
+            `t1`.`auth_expired_at` AS `users.auth_expired_at`,
+            `t1`.`reset_token` AS `users.reset_token`,
+            `t1`.`reset_expired_at` AS `user.reset_expired_at`,
+            `t1`.`is_deleted` AS `users.is_deleted`,
+            `t1`.`created_at` AS `users.created_at`,
+            `t1`.`updated_at` AS `users.updated_at`,
+
+            `t2`.`anonymous_nickname` AS `students.anonymous_nickname`,
+            `t2`.`student_number` AS `students.student_number`,
+            `t2`.`major` AS `students.major`,
+            `t2`.`identity` AS `students.identity`,
+            `t2`.`is_graduated` AS `students.is_graduated`,
+
+            `t3`.`company_registration_number` AS `owners.company_registration_number`,
+            `t3`.`company_registration_certificate_image_url` AS `owners.company_registration_certificate_image_url`,
+            `t3`.`grant_shop` AS `owners.grant_shop`,
+            `t3`.`grant_event` AS `owners.grant_event`,
+
+            `t4`.`id` AS `admins.id`,
+            `t4`.`user_id` AS `admins.user_id`,
+            `t4`.`grant_user` AS `admins.grant_user`,
+            `t4`.`grant_callvan` AS `admins.grant_callvan`,
+            `t4`.`grant_land` AS `admins.grant_land`,
+            `t4`.`grant_community` AS `admins.grant_community`,
+            `t4`.`grant_shop` AS `admins.grant_shop`,
+            `t4`.`grant_version` AS `admins.grant_version`,
+            `t4`.`grant_market` AS `admins.grant_market`,
+            `t4`.`grant_circle` AS `admins.grant_circle`,
+            `t4`.`grant_lost` AS `admins.grant_lost`,
+            `t4`.`grant_survey` AS `admins.grant_survey`,
+            `t4`.`grant_bcsdlab` AS `admins.grant_bcsdlab`,
+            `t4`.`grant_event` AS `admins.grant_event`,
+            `t4`.`is_deleted` AS `admins.is_deleted`,
+            `t4`.`created_at` AS `admins.created_at`,
+            `t4`.`updated_at` AS `admins.updated_at`
+
+        FROM (
+            SELECT *
+            FROM `koin`.`users`
+            WHERE
+                `nickname` = #{nickname}
+                AND `is_deleted` = 0
+        ) `t1`
+
+            LEFT JOIN `koin`.`students` `t2`
+            ON `t1`.`id` = `t2`.`user_id`
+
+            LEFT JOIN `koin`.`owners` `t3`
+            ON `t1`.`id` = `t3`.`user_id`
+
+            LEFT JOIN `koin`.`admins` `t4`
+            ON
+                `t1`.`id` = `t4`.`user_id`
+                AND `t4`.`is_deleted` = 0
+    </select>
+
+
     <select id="getUserById" resultMap="UserDiscriminator">
         SELECT * FROM koin.users WHERE ID = #{id};
     </select>


### PR DESCRIPTION
- ExceptionInformation enum에 관련 에러 메시지 추가 ([최신화](https://docs.google.com/spreadsheets/d/1yWYFqGOPA_6ZQQ4Mb7bvOyUMH9NbyBnIuJ8jz6XkwUA/edit#gid=0))
- 요청 닉네임 `제약조건 검사`와 `중복 확인 검사`를 각각의 메소드로 분리

#### 로직
다음 제시되는 과정은 `nickname` 컬럼에 대한 unique 제약조건을 제거하였기 때문에 가능함.

   - 닉네임으로 조회된 회원이 이메일 인증이 완료된(`is_authed`가 true) 회원이면 중복으로 처리
   - 반면, 닉네임으로 조회된 회원이 이메일 인증이 완료되지 않았다면 다음과 같이 처리
       - 이메일 인증 대기중(이메일 인증 폼 발송 후 1시간 이내)이라면 중복으로 처리
       - 이메일 인증 대기중이 아니라면 없는 회원으로 간주하기 때문에 중복이 아니라고 처리
          - 인증 폼 발송 후 1시간이 지났거나, `auth_token == null || auth_expired_at == null`일 때 