### PR TITLE
Refactor: 게시물 단건 조회 API에서 유저 인증 문제

### DIFF
--- a/src/main/java/koreatech/in/interceptor/AuthInterceptor.java
+++ b/src/main/java/koreatech/in/interceptor/AuthInterceptor.java
@@ -75,6 +75,10 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
 
         User user = jwtValidator.validate(request.getHeader("Authorization"));
 
+        if (user == null) {
+            throw new BaseException(BAD_ACCESS);
+        }
+
         // 어드민용 controller
         if (auth.role() == Auth.Role.ADMIN) {
             // 어드민 유저가 아니라면

--- a/src/main/java/koreatech/in/service/JwtValidator.java
+++ b/src/main/java/koreatech/in/service/JwtValidator.java
@@ -32,20 +32,16 @@ public class JwtValidator {
 
     public User validate(String header) {
         if (header == null || !header.startsWith("Bearer ")) {
-            throw new BaseException(BAD_ACCESS);
+            return null;
         }
 
         String accessToken = header.substring(7);
         if (accessToken.equals("undefined")) { // 추후 프론트엔드 측에서 변경
-            throw new BaseException(BAD_ACCESS);
+            return null;
         }
 
         Integer userId = jwtTokenGenerator.me(accessToken);
         User user = userMapper.getAuthedUserById(userId);
-
-        if (user == null) {
-            throw new BaseException(BAD_ACCESS);
-        }
 
         return user;
     }


### PR DESCRIPTION
- `GET /articles/{id}`에서 `@AuthExcept`로 인해 인증이 필요 없지만, 조회수 관련 로직에서 인증을 통해 회원의 정보를 가져오는 부분이 있다.
- 해당 유저 정보가 `null`일시 그냥 무시하지만, 유저 코드 리팩토링 과정중 회원 정보가 조회되지 않으면 null을 반환하는 것이 아닌 바로 Exception을 throw하는 방식으로 수정하였기에 문제 발생.
- 따라서 유저 정보가 조회되지 않으면 `null`을 반환하는 것으로 수정. 

참고
- 다른 API에도 이와 같은 사이드 이펙트가 있는지 확인해볼 필요 있음.
- 현재 `GET /articles/{id}` API에서는 필요 없는 데이터들까지 응답하고 있음. 이는 추후 리팩토링 필요.