### PR TITLE
BugFix: 비밀번호 변경 토큰이 만료되어도 경고문에는 수정되었다고 나오던 문제 수정

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.util.HashMap;
 import java.util.Map;
 
 @Auth(role = Auth.Role.USER)
@@ -152,15 +153,21 @@ public class UserController {
 
     @AuthExcept
     @RequestMapping(value = "/user/change/password/submit", method = RequestMethod.POST)
-    public String changePasswordAuthenticate(@RequestBody Map<String, Object> params, @RequestParam String reset_token) {
+    public @ResponseBody
+    Map<String, Object> changePasswordAuthenticate(@RequestBody Map<String, Object> params, @RequestParam String reset_token) {
         String password = params.get("password").toString();
         boolean result = userService.changePasswordAuthenticate(password, reset_token);
 
-        if (!result) {
+        /*if (!result) {
             return "mail/error_config";
         }
 
-        return "mail/success_change_password_config";
+        return "mail/success_change_password_config";*/
+
+        // hotfix
+        return new HashMap<String, Object>() {{
+            put("success", result);
+        }};
     }
 
     @AuthExcept

--- a/src/main/webapp/WEB-INF/resources/js/password.check.js
+++ b/src/main/webapp/WEB-INF/resources/js/password.check.js
@@ -27,8 +27,14 @@ $("#submitButton").click(function () {
         type: 'post',
         contentType:'application/json; charset=utf-8',
         data: JSON.stringify({password: sha256(userPw)}),
-        success: function (html) {
-            alert('비밀번호 변경 성공!\n변경된 비밀번호로 로그인해주세요.');
+        success: function (response) {
+            if (response.success) {
+                alert('비밀번호 변경 성공!\n변경된 비밀번호로 로그인해주세요.');
+            }
+            else {
+                alert('유효시간이 만료되었습니다.\n메일 재발송 후 다시 진행해주세요.');
+            }
+
             location.href = '//koreatech.in';
         },
         error: function (a, b, c) {


### PR DESCRIPTION
- `POST /user/change/password/submit` 실행 후 나타나는 alert 경고창에서, reset token이 만료되었어도 비밀번호 변경에 성공했다는 문구가 뜨던 문제 수정
- `success` boolean 값을 반환하여 `true`일 경우 변경 성공, `false`일 경우 변경 실패임을 나타내어 ajax 응답 내용에서 분기 처리
- 임시방편적인 방법이므로, 현재 진행하고 있는 유저 리팩토링에서는 더 나은 방법이 없을지 고민 후 적용 필요