### PR TITLE
Task: 어드민 권한 생성 API 리팩토링

### DIFF
--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -107,6 +107,14 @@ public class AdminUserController {
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
+    @RequestMapping(value = "/admin/users/{userId}/permission", method = RequestMethod.POST)
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> createPermission(@ApiParam(value = "(optional: grant_callvan, grant_user, grant_shop, grant_community, grant_version, grant_land, grant_market, is_deleted)", required = false) @RequestBody Authority authority, @ApiParam(required = true) @PathVariable("userId") int userId) throws Exception {
+        adminUserService.createPermissionForAdmin(authority, userId);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
     @RequestMapping(value = "/admin/users/{userId}/permission", method = RequestMethod.GET)
     public @ResponseBody
     ResponseEntity getPermission(@ApiParam(required = true) @PathVariable("userId") int userId) throws Exception {
@@ -118,13 +126,6 @@ public class AdminUserController {
     public @ResponseBody
     ResponseEntity updatePermission(@ApiParam(value = "(optional: grant_callvan, grant_user, grant_shop, grant_community, grant_version, grant_land, grant_market, is_deleted)", required = false) @RequestBody Authority authority, @ApiParam(required = true) @PathVariable("userId") int userId) throws Exception {
         return new ResponseEntity<Authority>(adminUserService.updatePermissionForAdmin(authority, userId), HttpStatus.CREATED);
-    }
-
-    @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
-    @RequestMapping(value = "/admin/users/{userId}/permission", method = RequestMethod.POST)
-    public @ResponseBody
-    ResponseEntity createPermission(@ApiParam(value = "(optional: grant_callvan, grant_user, grant_shop, grant_community, grant_version, grant_land, grant_market, is_deleted)", required = false) @RequestBody Authority authority, @ApiParam(required = true) @PathVariable("userId") int userId) throws Exception {
-        return new ResponseEntity<Authority>(adminUserService.createPermissionForAdmin(authority, userId), HttpStatus.CREATED);
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -107,8 +107,25 @@ public class AdminUserController {
         return new ResponseEntity<Map<String, Object>>(adminUserService.deleteUserForAdmin(id), HttpStatus.OK);
     }
 
-
-    @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
+    @ApiOperation(
+            value = "특정 회원에 대한 어드민 권한 생성",
+            notes = "다음의 경우 회원에 대한 어드민 권한 부여가 불가능합니다. \n" +
+                    "- 회원의 신원이 학생이 아닐 때 \n" +
+                    "- 탈퇴한(soft delete된) 회원일 때 \n" +
+                    "- 회원의 어드민 권한이 이미 존재할 때 \n" +
+                    "- 회원이 아직 이메일 인증을 완료하지 않았을 때 \n",
+            authorizations = {@Authorization("Authorization")}
+    )
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001)", response = ExceptionResponse.class),
+            @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message = "- 회원이 조회되지 않을 때 (code: 101008)", response = ExceptionResponse.class),
+            @ApiResponse(code = 409, message = "- 회원의 신원이 학생이 아닐 때 (code: 101003) \n\n" +
+                                               "- 탈퇴한 회원일 때 (code: 101005) \n\n" +
+                                               "- 회원의 어드민 권한이 이미 존재할 때 (code: 101006) \n\n" +
+                                               "- 회원이 아직 이메일 인증을 완료하지 않았을 때 (code: 101007)", response = ExceptionResponse.class)
+    })
+    @ResponseStatus(HttpStatus.CREATED)
     @ParamValid
     @RequestMapping(value = "/admin/users/{id}/permission", method = RequestMethod.POST)
     public @ResponseBody

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -109,6 +109,7 @@ public class AdminUserController {
 
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
+    @ParamValid
     @RequestMapping(value = "/admin/users/{id}/permission", method = RequestMethod.POST)
     public @ResponseBody
     ResponseEntity<EmptyResponse> createAuthority(

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -11,6 +11,7 @@ import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.student.Student;
 import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
+import koreatech.in.dto.admin.user.request.CreateAuthorityRequest;
 import koreatech.in.dto.admin.user.request.LoginRequest;
 import koreatech.in.dto.admin.user.response.LoginResponse;
 import koreatech.in.service.admin.AdminUserService;
@@ -106,11 +107,14 @@ public class AdminUserController {
         return new ResponseEntity<Map<String, Object>>(adminUserService.deleteUserForAdmin(id), HttpStatus.OK);
     }
 
+
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
-    @RequestMapping(value = "/admin/users/{userId}/permission", method = RequestMethod.POST)
+    @RequestMapping(value = "/admin/users/{id}/permission", method = RequestMethod.POST)
     public @ResponseBody
-    ResponseEntity<EmptyResponse> createPermission(@ApiParam(value = "(optional: grant_callvan, grant_user, grant_shop, grant_community, grant_version, grant_land, grant_market, is_deleted)", required = false) @RequestBody Authority authority, @ApiParam(required = true) @PathVariable("userId") int userId) throws Exception {
-        adminUserService.createPermissionForAdmin(authority, userId);
+    ResponseEntity<EmptyResponse> createAuthority(
+            @ApiParam(required = true) @PathVariable("id") Integer userId,
+            @RequestBody(required = false) @Valid CreateAuthorityRequest request, BindingResult bindingResult) throws Exception {
+        adminUserService.createAuthority(request, userId);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 

--- a/src/main/java/koreatech/in/domain/Authority.java
+++ b/src/main/java/koreatech/in/domain/Authority.java
@@ -1,13 +1,15 @@
 package koreatech.in.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.Date;
 
-@Getter @Setter
+@Getter @Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class Authority {
     private Integer id;
     private Integer user_id;
@@ -27,69 +29,8 @@ public class Authority {
     private Date created_at;
     private Date updated_at;
 
-    @Override
-    public String toString() {
-        return "Authority{" +
-                "id=" + id +
-                ", user_id=" + user_id +
-                ", grant_user=" + grant_user +
-                ", grant_callvan=" + grant_callvan +
-                ", grant_land=" + grant_land +
-                ", grant_community=" + grant_community +
-                ", grant_shop=" + grant_shop +
-                ", grant_version=" + grant_version +
-                ", is_deleted=" + is_deleted +
-                ", created_at=" + created_at +
-                ", updated_at=" + updated_at +
-                ", grant_market=" + grant_market +
-                ", grant_circle=" + grant_circle +
-                ", grant_lost=" + grant_lost +
-                ", grant_survey=" + grant_survey +
-                ", grant_bcsdlab=" + grant_bcsdlab +
-                ", grant_event=" + grant_event +
-                '}';
-    }
-
-    public void init() {
-        if (this.grant_user == null) {
-            this.grant_user = false;
-        }
-        if (this.grant_callvan == null) {
-            this.grant_callvan = false;
-        }
-        if (this.grant_land == null) {
-            this.grant_land = false;
-        }
-        if (this.grant_community == null) {
-            this.grant_community = false;
-        }
-        if (this.grant_shop == null) {
-            this.grant_shop = false;
-        }
-        if (this.grant_version == null) {
-            this.grant_version = false;
-        }
-        if (this.grant_market == null) {
-            this.grant_market = false;
-        }
-        if (this.grant_circle == null) {
-            this.grant_circle = false;
-        }
-        if (this.grant_lost == null) {
-            this.grant_lost = false;
-        }
-        if (this.grant_survey == null) {
-            this.grant_survey = false;
-        }
-        if (this.grant_bcsdlab == null) {
-            this.grant_bcsdlab = false;
-        }
-        if (this.grant_event == null) {
-            this.grant_event = false;
-        }
-        if (this.is_deleted == null) {
-            this.is_deleted = false;
-        }
+    public void changeUserId(Integer userId) {
+        this.user_id = userId;
     }
 
     public void update(Authority authority) {

--- a/src/main/java/koreatech/in/domain/User/User.java
+++ b/src/main/java/koreatech/in/domain/User/User.java
@@ -147,6 +147,10 @@ public abstract class User {
         this.reset_expired_at = new Date();
     }
 
+    public boolean hasWithdrawn() {
+        return this.is_deleted;
+    }
+
     public void changePassword(String password){
         this.password = password;
     }

--- a/src/main/java/koreatech/in/dto/admin/user/request/CreateAuthorityRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/user/request/CreateAuthorityRequest.java
@@ -1,0 +1,56 @@
+package koreatech.in.dto.admin.user.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class CreateAuthorityRequest {
+    @ApiModelProperty(notes = "회원 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "true")
+    private Boolean grant_user = false;
+
+    @ApiModelProperty(notes = "콜밴 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "false")
+    private Boolean grant_callvan = false;
+
+    @ApiModelProperty(notes = "복덕방 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "true")
+    private Boolean grant_land = false;
+
+    @ApiModelProperty(notes = "커뮤니티 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "false")
+    private Boolean grant_community = false;
+
+    @ApiModelProperty(notes = "상점 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "true")
+    private Boolean grant_shop = false;
+
+    @ApiModelProperty(notes = "버전 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "false")
+    private Boolean grant_version = false;
+
+    @ApiModelProperty(notes = "중고장터 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "true")
+    private Boolean grant_market = false;
+
+    @ApiModelProperty(notes = "동아리 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "false")
+    private Boolean grant_circle = false;
+
+    @ApiModelProperty(notes = "분실물 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "true")
+    private Boolean grant_lost = false;
+
+    @ApiModelProperty(notes = "설문조사 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "false")
+    private Boolean grant_survey = false;
+
+    @ApiModelProperty(notes = "bcsdlab 페이지 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "true")
+    private Boolean grant_bcsdlab = false;
+
+    @ApiModelProperty(notes = "이벤트 서비스 관리 권한 \n" +
+                              "- null일 경우 false로 요청됨", example = "false")
+    private Boolean grant_event = false;
+}

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -17,6 +17,11 @@ public enum ExceptionInformation {
     USER_NOT_FOUND("회원이 존재하지 않습니다.", 101000, HttpStatus.UNAUTHORIZED),
     PASSWORD_DIFFERENT("비밀번호가 일치하지 않습니다.", 101001, HttpStatus.UNAUTHORIZED),
     NICKNAME_DUPLICATE("이미 존재하는 닉네임입니다.", 101002, HttpStatus.CONFLICT),
+    USER_IS_NOT_STUDENT("회원의 신원이 학생이 아닙니다.", 101003, HttpStatus.CONFLICT),
+    USER_IS_NOT_OWNER("회원의 신원이 사장님이 아닙니다.", 101004, HttpStatus.CONFLICT),
+    USER_HAS_WITHDRAWN("탈퇴한 회원입니다.", 101005, HttpStatus.CONFLICT),
+    USER_ALREADY_HAS_ADMIN_AUTHORITY("회원의 권한이 이미 존재합니다.", 101006, HttpStatus.CONFLICT),
+    USER_HAS_NOT_COMPLETED_EMAIL_AUTHENTICATION("회원이 아직 이메일 인증을 완료하지 않았습니다.",101007, HttpStatus.CONFLICT),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -20,8 +20,9 @@ public enum ExceptionInformation {
     USER_IS_NOT_STUDENT("회원의 신원이 학생이 아닙니다.", 101003, HttpStatus.CONFLICT),
     USER_IS_NOT_OWNER("회원의 신원이 사장님이 아닙니다.", 101004, HttpStatus.CONFLICT),
     USER_HAS_WITHDRAWN("탈퇴한 회원입니다.", 101005, HttpStatus.CONFLICT),
-    USER_ALREADY_HAS_ADMIN_AUTHORITY("회원의 권한이 이미 존재합니다.", 101006, HttpStatus.CONFLICT),
+    USER_ALREADY_HAS_ADMIN_AUTHORITY("회원의 어드민 권한이 이미 존재합니다.", 101006, HttpStatus.CONFLICT),
     USER_HAS_NOT_COMPLETED_EMAIL_AUTHENTICATION("회원이 아직 이메일 인증을 완료하지 않았습니다.",101007, HttpStatus.CONFLICT),
+    INQUIRED_USER_NOT_FOUND("조회한 회원이 존재하지 않습니다.", 101008, HttpStatus.NOT_FOUND),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/mapstruct/admin/user/AdminAuthorityConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/admin/user/AdminAuthorityConverter.java
@@ -1,0 +1,13 @@
+package koreatech.in.mapstruct.admin.user;
+
+import koreatech.in.domain.Authority;
+import koreatech.in.dto.admin.user.request.CreateAuthorityRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface AdminAuthorityConverter {
+    AdminAuthorityConverter INSTANCE = Mappers.getMapper(AdminAuthorityConverter.class);
+
+    Authority toAuthority(CreateAuthorityRequest request);
+}

--- a/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
+++ b/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
@@ -1,5 +1,6 @@
 package koreatech.in.repository.admin;
 
+import koreatech.in.domain.Authority;
 import koreatech.in.domain.User.User;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
@@ -7,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AdminUserMapper {
     User getUserById(@Param("id") Integer id);
+    void createAdmin(@Param("admin") Authority admin);
 }

--- a/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
+++ b/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
@@ -1,0 +1,10 @@
+package koreatech.in.repository.admin;
+
+import koreatech.in.domain.User.User;
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminUserMapper {
+    User getUserById(@Param("id") Integer id);
+}

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -4,6 +4,7 @@ import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.student.Student;
+import koreatech.in.dto.admin.user.request.CreateAuthorityRequest;
 import koreatech.in.dto.admin.user.request.LoginRequest;
 import koreatech.in.dto.admin.user.response.LoginResponse;
 
@@ -24,7 +25,7 @@ public interface AdminUserService {
 
     Map<String, Object> deleteUserForAdmin(int id);
 
-    void createPermissionForAdmin(Authority authority, int userId);
+    void createAuthority(CreateAuthorityRequest request, Integer userId);
 
     Authority getPermissionForAdmin(int userId);
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -24,7 +24,7 @@ public interface AdminUserService {
 
     Map<String, Object> deleteUserForAdmin(int id);
 
-    Authority createPermissionForAdmin(Authority authority, int userId);
+    void createPermissionForAdmin(Authority authority, int userId);
 
     Authority getPermissionForAdmin(int userId);
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -237,7 +237,7 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Transactional
     @Override
-    public Authority createPermissionForAdmin(Authority authority, int userId) {
+    public void createPermissionForAdmin(Authority authority, int userId) {
         User selectUser = userMapper.getUserById(userId);
         if(selectUser == null){
             throw new NotFoundException(new ErrorMessage("No User", 0));
@@ -252,8 +252,6 @@ public class AdminUserServiceImpl implements AdminUserService {
         }
 
         authorityMapper.createAuthority(authority);
-
-        return authority;
     }
 
     @Override

--- a/src/main/resources/db/migration/V49__remove_user_id_unique_constraint_of_admins_table.sql
+++ b/src/main/resources/db/migration/V49__remove_user_id_unique_constraint_of_admins_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `koin`.`admins`
+    DROP INDEX `admins_user_id_unique` ;
+;

--- a/src/main/resources/mapper/admin/AdminUserMapper.xml
+++ b/src/main/resources/mapper/admin/AdminUserMapper.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="koreatech.in.repository.admin.AdminUserMapper">
+    <select id="getUserById" parameterType="integer" resultMap="UserDiscriminator">
+        SELECT
+            `t1`.`id` AS `users.id`,
+            `t1`.`account` AS `users.account`,
+            `t1`.`password` AS `users.password`,
+            `t1`.`nickname` AS `users.nickname`,
+            `t1`.`name` AS `users.name`,
+            `t1`.`phone_number` AS `users.phone_number`,
+            `t1`.`user_type` AS `users.user_type`,
+            `t1`.`email` AS `users.email`,
+            `t1`.`gender` AS `users.gender`,
+            `t1`.`is_authed` AS `users.is_authed`,
+            `t1`.`last_logged_at` AS `users.last_logged_at`,
+            `t1`.`profile_image_url` AS `users.profile_image_url`,
+            `t1`.`auth_token` AS `users.auth_token`,
+            `t1`.`auth_expired_at` AS `users.auth_expired_at`,
+            `t1`.`reset_token` AS `users.reset_token`,
+            `t1`.`reset_expired_at` AS `users.reset_expired_at`,
+            `t1`.`is_deleted` AS `users.is_deleted`,
+            `t1`.`created_at` AS `users.created_at`,
+            `t1`.`updated_at` AS `users.updated_at`,
+
+            `t2`.`anonymous_nickname` AS `students.anonymous_nickname`,
+            `t2`.`student_number` AS `students.student_number`,
+            `t2`.`major` AS `students.major`,
+            `t2`.`identity` AS `students.identity`,
+            `t2`.`is_graduated` AS `students.is_graduated`,
+
+            `t3`.`company_registration_number` AS `owners.company_registration_number`,
+            `t3`.`company_registration_certificate_image_url` AS `owners.company_registration_certificate_image_url`,
+            `t3`.`grant_shop` AS `owners.grant_shop`,
+            `t3`.`grant_event` AS `owners.grant_event`,
+
+            `t4`.`id` AS `admins.id`,
+            `t4`.`user_id` AS `admins.user_id`,
+            `t4`.`grant_user` AS `admins.grant_user`,
+            `t4`.`grant_callvan` AS `admins.grant_callvan`,
+            `t4`.`grant_land` AS `admins.grant_land`,
+            `t4`.`grant_community` AS `admins.grant_community`,
+            `t4`.`grant_shop` AS `admins.grant_shop`,
+            `t4`.`grant_version` AS `admins.grant_version`,
+            `t4`.`grant_market` AS `admins.grant_market`,
+            `t4`.`grant_circle` AS `admins.grant_circle`,
+            `t4`.`grant_lost` AS `admins.grant_lost`,
+            `t4`.`grant_survey` AS `admins.grant_survey`,
+            `t4`.`grant_bcsdlab` AS `admins.grant_bcsdlab`,
+            `t4`.`grant_event` AS `admins.grant_event`,
+            `t4`.`is_deleted` AS `admins.is_deleted`,
+            `t4`.`created_at` AS `admins.created_at`,
+            `t4`.`updated_at` AS `admins.updated_at`
+
+        FROM (
+            SELECT *
+            FROM `koin`.`users`
+            WHERE
+                `id` = #{id}
+        ) `t1`
+
+            LEFT JOIN `koin`.`students` `t2`
+            ON `t1`.`id` = `t2`.`user_id`
+
+            LEFT JOIN `koin`.`owners` `t3`
+            ON `t1`.`id` = `t3`.`user_id`
+
+            LEFT JOIN `koin`.`admins` `t4`
+            ON
+                `t1`.`id` = `t4`.`user_id`
+                AND `t4`.`is_deleted` = 0
+    </select>
+
+    <resultMap id="UserDiscriminator" type="koreatech.in.domain.User.User" >
+        <discriminator javaType="String" column="users.user_type">
+            <case value="STUDENT" resultMap="StudentResultMap"/>
+            <case value="OWNER" resultMap="OwnerResultMap"/>
+        </discriminator>
+    </resultMap>
+
+    <resultMap id="UserResultMap" type="koreatech.in.domain.User.User">
+        <id property="id" column="users.id"/>
+        <result property="account" column="users.account"/>
+        <result property="password" column="users.password"/>
+        <result property="nickname" column="users.nickname"/>
+        <result property="name" column="users.name"/>
+        <result property="phone_number" column="users.phone_number"/>
+        <result property="user_type" column="users.user_type"/>
+        <result property="email" column="users.email"/>
+        <result property="gender" column="users.gender"/>
+        <result property="is_authed" column="users.is_authed"/>
+        <result property="last_logged_at" column="users.last_logged_at"/>
+        <result property="profile_image_url" column="users.profile_image_url"/>
+        <result property="auth_token" column="users.auth_token"/>
+        <result property="auth_expired_at" column="users.auth_expired_at"/>
+        <result property="reset_token" column="users.reset_token"/>
+        <result property="reset_expired_at" column="users.reset_expired_at"/>
+        <result property="is_deleted" column="users.is_deleted"/>
+        <result property="created_at" column="users.created_at"/>
+        <result property="updated_at" column="users.updated_at"/>
+        <association property="authority" javaType="koreatech.in.domain.Authority">
+            <id property="id" column="admins.id"/>
+            <id property="user_id" column="admins.user_id"/>
+            <id property="grant_user" column="admins.grant_user"/>
+            <id property="grant_callvan" column="admins.grant_callvan"/>
+            <id property="grant_land" column="admins.grant_land"/>
+            <id property="grant_community" column="admins.grant_community"/>
+            <id property="grant_shop" column="admins.grant_shop"/>
+            <id property="grant_version" column="admins.grant_version"/>
+            <id property="grant_market" column="admins.grant_market"/>
+            <id property="grant_circle" column="admins.grant_circle"/>
+            <id property="grant_lost" column="admins.grant_lost"/>
+            <id property="grant_survey" column="admins.grant_survey"/>
+            <id property="grant_bcsdlab" column="admins.grant_bcsdlab"/>
+            <id property="grant_event" column="admins.grant_event"/>
+            <id property="is_deleted" column="admins.is_deleted"/>
+            <id property="created_at" column="admins.created_at"/>
+            <id property="updated_at" column="admins.updated_at"/>
+        </association>
+    </resultMap>
+
+    <resultMap id="StudentResultMap" extends="UserResultMap" type="koreatech.in.domain.User.student.Student">
+        <result property="anonymous_nickname" column="students.anonymous_nickname"/>
+        <result property="student_number" column="students.student_number"/>
+        <result property="major" column="students.major"/>
+        <result property="identity" column="students.identity"/>
+        <result property="is_graduated" column="students.is_graduated"/>
+    </resultMap>
+
+    <resultMap id="OwnerResultMap" extends="UserResultMap" type="koreatech.in.domain.User.owner.Owner">
+        <result property="company_registration_number" column="owners.company_registration_number"/>
+        <result property="company_registration_certificate_image_url" column="owners.company_registration_certificate_image_url"/>
+        <result property="grant_shop" column="owners.grant_shop"/>
+        <result property="grant_event" column="owners.grant_event"/>
+    </resultMap>
+</mapper>

--- a/src/main/resources/mapper/admin/AdminUserMapper.xml
+++ b/src/main/resources/mapper/admin/AdminUserMapper.xml
@@ -72,6 +72,39 @@
                 AND `t4`.`is_deleted` = 0
     </select>
 
+    <insert id="createAdmin">
+        INSERT INTO `koin`.`admins` (
+            `user_id`,
+            `grant_user`,
+            `grant_callvan`,
+            `grant_land`,
+            `grant_community`,
+            `grant_shop`,
+            `grant_version`,
+            `grant_market`,
+            `grant_circle`,
+            `grant_lost`,
+            `grant_survey`,
+            `grant_bcsdlab`,
+            `grant_event`
+        )
+        VALUES (
+            #{admin.user_id},
+            #{admin.grant_user},
+            #{admin.grant_callvan},
+            #{admin.grant_land},
+            #{admin.grant_community},
+            #{admin.grant_shop},
+            #{admin.grant_version},
+            #{admin.grant_market},
+            #{admin.grant_circle},
+            #{admin.grant_lost},
+            #{admin.grant_survey},
+            #{admin.grant_bcsdlab},
+            #{admin.grant_event}
+        )
+    </insert>
+
     <resultMap id="UserDiscriminator" type="koreatech.in.domain.User.User" >
         <discriminator javaType="String" column="users.user_type">
             <case value="STUDENT" resultMap="StudentResultMap"/>


### PR DESCRIPTION
`POST /admin/users/{id}/permission`

- controller/service 새로운 컨벤션에 맞게 반환 타입 수정
- service 리팩토링
- 관련 Exception enum message 정의
- admin 테이블에 soft delete 적용을 위해 user_id 컬럼의 unique 제약조건 제거
- Swagger 문서화