### PR TITLE
Task: 인증 번호 검증 기능

### DIFF
--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -60,15 +60,15 @@ public class OwnerController {
     }
 
     @ApiResponses({
-            @ApiResponse(code = 409, message = "- 요청받지 않은 이메일일 경우 (code: 101010) \n\n",
-                    response = ExceptionResponse.class),
-            @ApiResponse(code = 409, message = "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
+            @ApiResponse(code = 409, message = "- 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
+                    "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
                     response = ExceptionResponse.class),
             @ApiResponse(code = 410, message = "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",
                     response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- 인증 코드가 일치하지 않을 경우 (code: 121002) \n\n" +
-                    "- 이메일 도메인이 사용할 수 없는 경우 (code: 101009) \n\n",
-                    response = ExceptionResponse.class),
+            @ApiResponse(code = 422, message =
+                    "- 이메일 도메인이 사용할 수 없는 경우 (code: 101009) \n\n" +
+                    "- 인증 코드가 일치하지 않을 경우 (code: 121002) \n\n" ,
+                    response = ExceptionResponse.class)
     })
     @ApiOperation(value = "인증번호 입력")
     @AuthExcept

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -14,8 +14,12 @@ import koreatech.in.annotation.AuthExcept;
 import koreatech.in.annotation.ParamValid;
 import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
+import koreatech.in.dto.normal.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.owner.request.VerifyEmailRequest;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.service.OwnerService;
+import koreatech.in.util.StringXssChecker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -53,6 +57,21 @@ public class OwnerController {
         }
 
         ownerService.requestVerification(request);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @AuthExcept@RequestMapping(value = "/owners/verification/code", method = RequestMethod.POST)
+    @ParamValid
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> verifyCode(@RequestBody @Valid VerifyCodeRequest request,
+                                              BindingResult bindingResult) {
+        try {
+            request = StringXssChecker.xssCheck(request, new VerifyCodeRequest());
+        } catch (Exception exception) {
+            throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
+        }
+
+        ownerService.certificate(request);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -60,10 +60,10 @@ public class OwnerController {
     }
 
     @ApiResponses({
-            @ApiResponse(code = 409, message = "- 저장이 만료되었거나(`2시간`), 이메일 인증을 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
-                    "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
+            @ApiResponse(code = 409, message = "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
                     response = ExceptionResponse.class),
-            @ApiResponse(code = 410, message = "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",
+            @ApiResponse(code = 410, message = "- 저장기간(`2시간`)이 만료된 이메일일 경우 (code: 101010) \n\n"+
+                    "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",
                     response = ExceptionResponse.class),
             @ApiResponse(code = 422, message =
                     "- 이메일 도메인이 사용할 수 없는 경우 (code: 101009) \n\n" +

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -60,7 +60,7 @@ public class OwnerController {
     }
 
     @ApiResponses({
-            @ApiResponse(code = 409, message = "- 저장이 만료되었거나(`1일`), 이메일 인증을 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
+            @ApiResponse(code = 409, message = "- 저장이 만료되었거나(`2시간`), 이메일 인증을 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
                     "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
                     response = ExceptionResponse.class),
             @ApiResponse(code = 410, message = "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -60,7 +60,7 @@ public class OwnerController {
     }
 
     @ApiResponses({
-            @ApiResponse(code = 409, message = "- 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
+            @ApiResponse(code = 409, message = "- 저장이 만료되었거나(`1일`), 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
                     "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
                     response = ExceptionResponse.class),
             @ApiResponse(code = 410, message = "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -60,7 +60,8 @@ public class OwnerController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @AuthExcept@RequestMapping(value = "/owners/verification/code", method = RequestMethod.POST)
+    @AuthExcept
+    @RequestMapping(value = "/owners/verification/code", method = RequestMethod.POST)
     @ParamValid
     public @ResponseBody
     ResponseEntity<EmptyResponse> verifyCode(@RequestBody @Valid VerifyCodeRequest request,

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -5,7 +5,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
 import javax.validation.Valid;
 import koreatech.in.annotation.Auth;
 import koreatech.in.annotation.Auth.Authority;
@@ -38,13 +37,13 @@ public class OwnerController {
     @Autowired
     private OwnerService ownerService;
 
-    @AuthExcept
     @ApiResponses({
             @ApiResponse(code = 422, message = "- 이메일 주소가 올바르지 않을 경우 (code: 101008) \n\n" +
                     "- 이메일 도메인이 사용할 수 없는 경우 (code: 101009) \n\n",
                     response = ExceptionResponse.class),
     })
-    @ApiOperation(value = "인증번호 전송 요청", authorizations = {@Authorization("Authorization")})
+    @ApiOperation(value = "인증번호 전송 요청")
+    @AuthExcept
     @RequestMapping(value = "/owners/verification/email", method = RequestMethod.POST)
     @ParamValid
     public @ResponseBody
@@ -60,12 +59,24 @@ public class OwnerController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @ApiResponses({
+            @ApiResponse(code = 409, message = "- 요청받지 않은 이메일일 경우 (code: 101010) \n\n",
+                    response = ExceptionResponse.class),
+            @ApiResponse(code = 409, message = "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
+                    response = ExceptionResponse.class),
+            @ApiResponse(code = 410, message = "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",
+                    response = ExceptionResponse.class),
+            @ApiResponse(code = 422, message = "- 인증 코드가 일치하지 않을 경우 (code: 121002) \n\n" +
+                    "- 이메일 도메인이 사용할 수 없는 경우 (code: 101009) \n\n",
+                    response = ExceptionResponse.class),
+    })
+    @ApiOperation(value = "인증번호 입력")
     @AuthExcept
     @RequestMapping(value = "/owners/verification/code", method = RequestMethod.POST)
     @ParamValid
     public @ResponseBody
     ResponseEntity<EmptyResponse> verifyCode(@RequestBody @Valid VerifyCodeRequest request,
-                                              BindingResult bindingResult) {
+                                             BindingResult bindingResult) {
         try {
             request = StringXssChecker.xssCheck(request, new VerifyCodeRequest());
         } catch (Exception exception) {

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -60,7 +60,7 @@ public class OwnerController {
     }
 
     @ApiResponses({
-            @ApiResponse(code = 409, message = "- 저장이 만료되었거나(`1일`), 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
+            @ApiResponse(code = 409, message = "- 저장이 만료되었거나(`1일`), 이메일 인증을 요청받지 않은 이메일일 경우 (code: 101010) \n\n"+
                     "- 이미 인증이 완료된 이메일일 경우 (code: 121000) \n\n",
                     response = ExceptionResponse.class),
             @ApiResponse(code = 410, message = "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",

--- a/src/main/java/koreatech/in/domain/User/owner/EmailAddress.java
+++ b/src/main/java/koreatech/in/domain/User/owner/EmailAddress.java
@@ -17,6 +17,10 @@ public class EmailAddress {
         return localParts.getValue() + domainSeparator + domain.getValue();
     }
 
+    public static EmailAddress from(String fullAddress) {
+        return new EmailAddress(LocalParts.from(fullAddress), Domain.from(fullAddress));
+    }
+
     static void validates(String fullAddress) {
         if (!isValidEmailForm(getSeparateIndex(fullAddress))) {
             throw new BaseException(ExceptionInformation.EMAIL_ADDRESS_INVALID);

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerInCertification.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerInCertification.java
@@ -1,0 +1,18 @@
+package koreatech.in.domain.User.owner;
+
+import lombok.Getter;
+
+@Getter
+public class OwnerInCertification extends Owner {
+
+    private final String certificationCode;
+
+    private OwnerInCertification(String emailFullPath, String certificationCode) {
+        this.email = emailFullPath;
+        this.certificationCode = certificationCode;
+    }
+
+    public static OwnerInCertification from(EmailAddress emailAddress, CertificationCode certificationCode) {
+        return new OwnerInCertification(emailAddress.getEmailAddress(), certificationCode.getValue());
+    }
+}

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerInCertification.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerInCertification.java
@@ -1,8 +1,10 @@
 package koreatech.in.domain.User.owner;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class OwnerInCertification extends Owner {
 
     private final String certificationCode;

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
@@ -9,10 +9,10 @@ public class OwnerInVerification extends Owner {
 
     private final String certificationCode;
 
-    private OwnerInVerification(String certificationCode, Boolean is_authed, Date auth_expired_at) {
+    private OwnerInVerification(String certificationCode, Boolean isAuthed, Date authExpiredAt) {
         this.certificationCode = certificationCode;
-        this.is_authed = is_authed;
-        this.auth_expired_at = auth_expired_at;
+        this.is_authed = isAuthed;
+        this.auth_expired_at = authExpiredAt;
     }
 
     public static OwnerInVerification from(CertificationCode certificationCode) {

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
@@ -21,6 +21,18 @@ public class OwnerInVerification extends Owner {
         return new OwnerInVerification(certificationCode.getValue(), false, DateUtil.addMinute(new Date(), 5));
     }
 
+    public void validateFields() {
+        if (this.certificationCode == null) {
+            throw new NullPointerException("Redis에 있는 OwnerInVerification 객체의 certificationCode 필드가 비어있습니다.");
+        }
+        if (this.is_authed == null) {
+            throw new NullPointerException("Redis에 있는 OwnerInVerification 객체의 is_authed 필드가 비어있습니다.");
+        }
+        if (this.auth_expired_at == null) {
+            throw new NullPointerException("Redis에 있는 OwnerInVerification 객체의 auth_expired_at 필드가 비어있습니다.");
+        }
+    }
+
     public void validateFor(OwnerInCertification ownerInCertification) {
         validateDuplication();
         validateExpiration();

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
@@ -29,22 +29,19 @@ public class OwnerInVerification extends Owner {
 
     private void validateDuplication() {
         if(this.getIs_authed().equals(true)) {
-            //TODO DuplicatedCertification
-            throw  new BaseException(ExceptionInformation.FORBIDDEN);
+            throw  new BaseException(ExceptionInformation.CERTIFICATION_CODE_ALREADY_COMPLETED);
         }
     }
 
     private void validateExpiration() {
         if (DateUtil.isExpired(this.auth_expired_at, new Date())) {
-            //TODO ExpiredCertification
-            throw new BaseException(ExceptionInformation.FORBIDDEN);
+            throw new BaseException(ExceptionInformation.CERTIFICATION_CODE_EXPIRED);
         }
     }
 
     private void validateCode(String certificationCode) {
         if (!this.getCertificationCode().equals(certificationCode)) {
-            //TODO InvalidCertificationCode
-            throw new BaseException(ExceptionInformation.FORBIDDEN);
+            throw new BaseException(ExceptionInformation.CERTIFICATION_CODE_INVALID);
         }
     }
 }

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
@@ -40,8 +40,8 @@ public class OwnerInVerification extends Owner {
     }
 
     private void validateDuplication() {
-        if(this.getIs_authed().equals(true)) {
-            throw  new BaseException(ExceptionInformation.CERTIFICATION_CODE_ALREADY_COMPLETED);
+        if (this.getIs_authed().equals(true)) {
+            throw new BaseException(ExceptionInformation.CERTIFICATION_CODE_ALREADY_COMPLETED);
         }
     }
 

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerInVerification.java
@@ -1,6 +1,8 @@
 package koreatech.in.domain.User.owner;
 
 import java.util.Date;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.util.DateUtil;
 import lombok.Getter;
 
@@ -17,5 +19,32 @@ public class OwnerInVerification extends Owner {
 
     public static OwnerInVerification from(CertificationCode certificationCode) {
         return new OwnerInVerification(certificationCode.getValue(), false, DateUtil.addMinute(new Date(), 5));
+    }
+
+    public void validateFor(OwnerInCertification ownerInCertification) {
+        validateDuplication();
+        validateExpiration();
+        validateCode(ownerInCertification.getCertificationCode());
+    }
+
+    private void validateDuplication() {
+        if(this.getIs_authed().equals(true)) {
+            //TODO DuplicatedCertification
+            throw  new BaseException(ExceptionInformation.FORBIDDEN);
+        }
+    }
+
+    private void validateExpiration() {
+        if (DateUtil.isExpired(this.auth_expired_at, new Date())) {
+            //TODO ExpiredCertification
+            throw new BaseException(ExceptionInformation.FORBIDDEN);
+        }
+    }
+
+    private void validateCode(String certificationCode) {
+        if (!this.getCertificationCode().equals(certificationCode)) {
+            //TODO InvalidCertificationCode
+            throw new BaseException(ExceptionInformation.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/koreatech/in/dto/normal/owner/request/VerifyCodeRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/owner/request/VerifyCodeRequest.java
@@ -1,0 +1,28 @@
+package koreatech.in.dto.normal.owner.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class VerifyCodeRequest {
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotNull(message = "이메일은 필수입니다.")
+    @ApiModelProperty(notes = "이메일 주소 \n" +
+            "- not null \n" +
+            "- 이메일 형식이어야 함", required = true)
+    private String address;
+
+    @NotBlank(message = "인증 코드는 필수입니다.")
+    @Digits(integer = 6, fraction = 0, message = "인증 코드는 6자리 정수여야 합니다.")
+    @ApiModelProperty(notes = "인증코드 \n" +
+            "- not blank \n" +
+            "- 6자리 정수여야 함", required = true)
+    private String certificationCode;
+}

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -24,6 +24,7 @@ public enum ExceptionInformation {
     IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_EMAIL_EXIST("탈퇴하지 않은 회원 중 같은 이메일을 가진 회원이 있어, 탈퇴를 해제할 수 없습니다.", 101007, HttpStatus.CONFLICT),
     EMAIL_ADDRESS_INVALID("유효하지 않는 이메일 주소입니다.", 101008, HttpStatus.UNPROCESSABLE_ENTITY),
     EMAIL_DOMAIN_INVALID("유효하지 않는 이메일 도메인입니다.", 101009, HttpStatus.UNPROCESSABLE_ENTITY),
+    EMAIL_ADDRESS_NOT_REQUESTED("요청받지 않은 이메일 주소입니다.", 101010, HttpStatus.CONFLICT),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -24,7 +24,7 @@ public enum ExceptionInformation {
     IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_EMAIL_EXIST("탈퇴하지 않은 회원 중 같은 이메일을 가진 회원이 있어, 탈퇴를 해제할 수 없습니다.", 101007, HttpStatus.CONFLICT),
     EMAIL_ADDRESS_INVALID("유효하지 않는 이메일 주소입니다.", 101008, HttpStatus.UNPROCESSABLE_ENTITY),
     EMAIL_DOMAIN_INVALID("유효하지 않는 이메일 도메인입니다.", 101009, HttpStatus.UNPROCESSABLE_ENTITY),
-    EMAIL_ADDRESS_NOT_REQUESTED("요청받지 않은 이메일 주소입니다.", 101010, HttpStatus.CONFLICT),
+    EMAIL_ADDRESS_EXPIRED_OR_NOT_REQUESTED("저장이 만료되었거나 요청받지 않은 이메일 주소입니다. 다시 회원가입을 시도해주세요.", 101010, HttpStatus.CONFLICT),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -24,7 +24,7 @@ public enum ExceptionInformation {
     IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_EMAIL_EXIST("탈퇴하지 않은 회원 중 같은 이메일을 가진 회원이 있어, 탈퇴를 해제할 수 없습니다.", 101007, HttpStatus.CONFLICT),
     EMAIL_ADDRESS_INVALID("유효하지 않는 이메일 주소입니다.", 101008, HttpStatus.UNPROCESSABLE_ENTITY),
     EMAIL_DOMAIN_INVALID("유효하지 않는 이메일 도메인입니다.", 101009, HttpStatus.UNPROCESSABLE_ENTITY),
-    EMAIL_ADDRESS_EXPIRED_OR_NOT_REQUESTED("저장이 만료되었거나 요청받지 않은 이메일 주소입니다. 다시 회원가입을 시도해주세요.", 101010, HttpStatus.CONFLICT),
+    EMAIL_ADDRESS_EXPIRED_OR_NOT_REQUESTED("저장이 만료되었거나 이메일 인증을 요청받지 않은 이메일 주소입니다. 다시 회원가입을 시도해주세요.", 101010, HttpStatus.CONFLICT),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -54,6 +54,9 @@ public enum ExceptionInformation {
     FILES_LENGTH_OVER("파일목록의 길이가 최대보다 큽니다.", 110003, HttpStatus.CONFLICT),
 
     // ======= 사장님 =======
+    CERTIFICATION_CODE_ALREADY_COMPLETED("해당 이메일은 이미 인증 완료되었습니다.", 121000, HttpStatus.CONFLICT),
+    CERTIFICATION_CODE_EXPIRED("코드 인증 기한이 경과되었습니다.", 121001, HttpStatus.GONE),
+    CERTIFICATION_CODE_INVALID("인증 코드가 일치하지 않습니다.", 121002, HttpStatus.UNPROCESSABLE_ENTITY),
 
     // ======= BCSDLab 트랙 =======
     TRACK_NOT_FOUND("트랙이 존재하지 않습니다.", 201000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -24,7 +24,7 @@ public enum ExceptionInformation {
     IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_EMAIL_EXIST("탈퇴하지 않은 회원 중 같은 이메일을 가진 회원이 있어, 탈퇴를 해제할 수 없습니다.", 101007, HttpStatus.CONFLICT),
     EMAIL_ADDRESS_INVALID("유효하지 않는 이메일 주소입니다.", 101008, HttpStatus.UNPROCESSABLE_ENTITY),
     EMAIL_DOMAIN_INVALID("유효하지 않는 이메일 도메인입니다.", 101009, HttpStatus.UNPROCESSABLE_ENTITY),
-    EMAIL_ADDRESS_EXPIRED_OR_NOT_REQUESTED("저장이 만료되었거나 이메일 인증을 요청받지 않은 이메일 주소입니다. 다시 회원가입을 시도해주세요.", 101010, HttpStatus.CONFLICT),
+    EMAIL_ADDRESS_SAVE_EXPIRED("저장기간이 만료된 이메일 주소입니다. 다시 회원가입을 시도해주세요.", 101010, HttpStatus.GONE),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -3,6 +3,8 @@ package koreatech.in.mapstruct;
 import koreatech.in.domain.User.owner.Domain;
 import koreatech.in.domain.User.owner.EmailAddress;
 import koreatech.in.domain.User.owner.LocalParts;
+import koreatech.in.domain.User.owner.OwnerInCertification;
+import koreatech.in.dto.normal.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.owner.request.VerifyEmailRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -30,4 +32,16 @@ public interface OwnerConverter {
     default Domain convertDomain(String address) {
         return Domain.from(address);
     }
+
+    @Mappings({
+            @Mapping(source = "address", target = "email", qualifiedByName = "convertEmail"),
+            @Mapping(source = "certificationCode", target = "certificationCode")
+    })
+    OwnerInCertification toOwnerInCertification(VerifyCodeRequest verifyCodeRequest);
+
+    @Named("convertEmail")
+    default String convertEmail(String address) {
+        return EmailAddress.from(address).getEmailAddress();
+    }
+
 }

--- a/src/main/java/koreatech/in/service/OwnerService.java
+++ b/src/main/java/koreatech/in/service/OwnerService.java
@@ -1,8 +1,11 @@
 package koreatech.in.service;
 
+import koreatech.in.dto.normal.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.owner.request.VerifyEmailRequest;
 
 public interface OwnerService {
 
     void requestVerification(VerifyEmailRequest verifyEmailRequest);
+
+    void certificate(VerifyCodeRequest verifyCodeRequest);
 }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -76,7 +76,7 @@ public class OwnerServiceImpl implements OwnerService {
 
     private static void validateRedis(OwnerInVerification ownerInRedis) {
         if(ownerInRedis == null) {
-            throw  new BaseException(ExceptionInformation.EMAIL_ADDRESS_NOT_REQUESTED);
+            throw  new BaseException(ExceptionInformation.EMAIL_ADDRESS_EXPIRED_OR_NOT_REQUESTED);
         }
         ownerInRedis.validateFields();
     }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -12,6 +12,8 @@ import koreatech.in.domain.User.owner.OwnerInCertification;
 import koreatech.in.domain.User.owner.OwnerInVerification;
 import koreatech.in.dto.normal.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.owner.request.VerifyEmailRequest;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.mapstruct.OwnerConverter;
 import koreatech.in.util.RandomGenerator;
 import koreatech.in.util.SesMailSender;
@@ -67,9 +69,16 @@ public class OwnerServiceImpl implements OwnerService {
         String json = stringRedisUtilStr.valOps.get(redisOwnerAuthPrefix + ownerInCertification.getEmail());
 
         OwnerInVerification ownerInRedis = gson.fromJson(json, OwnerInVerification.class);
-        ownerInRedis.validateForRedis();
+        validateRedis(ownerInRedis);
 
         return ownerInRedis;
+    }
+
+    private static void validateRedis(OwnerInVerification ownerInRedis) {
+        if(ownerInRedis == null) {
+            throw  new BaseException(ExceptionInformation.EMAIL_ADDRESS_NOT_REQUESTED);
+        }
+        ownerInRedis.validateFields();
     }
 
     private void putRedisFor(String emailAddress, OwnerInVerification ownerInVerification) {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -44,7 +44,7 @@ public class OwnerServiceImpl implements OwnerService {
         CertificationCode certificationCode = RandomGenerator.getCertificationCode();
         OwnerInVerification ownerInVerification = OwnerInVerification.from(certificationCode);
 
-        putRedisFor(emailAddress, ownerInVerification);
+        putRedisFor(emailAddress.getEmailAddress(), ownerInVerification);
         sendMailFor(emailAddress, certificationCode);
 
     }
@@ -54,7 +54,7 @@ public class OwnerServiceImpl implements OwnerService {
 
     }
 
-    private void putRedisFor(EmailAddress emailAddress, OwnerInVerification ownerInVerification) {
+    private void putRedisFor(String emailAddress, OwnerInVerification ownerInVerification) {
         Gson gson = new GsonBuilder().create();
 
         stringRedisUtilStr.valOps.set(redisOwnerAuthPrefix + emailAddress.getEmailAddress(),

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 import koreatech.in.domain.User.owner.CertificationCode;
 import koreatech.in.domain.User.owner.EmailAddress;
 import koreatech.in.domain.User.owner.OwnerInVerification;
+import koreatech.in.dto.normal.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.owner.request.VerifyEmailRequest;
 import koreatech.in.mapstruct.OwnerConverter;
 import koreatech.in.util.RandomGenerator;
@@ -45,6 +46,11 @@ public class OwnerServiceImpl implements OwnerService {
 
         putRedisFor(emailAddress, ownerInVerification);
         sendMailFor(emailAddress, certificationCode);
+
+    }
+
+    @Override
+    public void certificate(VerifyCodeRequest verifyCodeRequest) {
 
     }
 

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -76,7 +76,7 @@ public class OwnerServiceImpl implements OwnerService {
 
     private static void validateRedis(OwnerInVerification ownerInRedis) {
         if(ownerInRedis == null) {
-            throw  new BaseException(ExceptionInformation.EMAIL_ADDRESS_EXPIRED_OR_NOT_REQUESTED);
+            throw  new BaseException(ExceptionInformation.EMAIL_ADDRESS_SAVE_EXPIRED);
         }
         ownerInRedis.validateFields();
     }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -66,7 +66,10 @@ public class OwnerServiceImpl implements OwnerService {
         Gson gson = new GsonBuilder().create();
         String json = stringRedisUtilStr.valOps.get(redisOwnerAuthPrefix + ownerInCertification.getEmail());
 
-        return gson.fromJson(json, OwnerInVerification.class);
+        OwnerInVerification ownerInRedis = gson.fromJson(json, OwnerInVerification.class);
+        ownerInRedis.validateForRedis();
+
+        return ownerInRedis;
     }
 
     private void putRedisFor(String emailAddress, OwnerInVerification ownerInVerification) {


### PR DESCRIPTION
# 회원가입
## 인증번호 검증
1. `Controller`에 인증 코드 검증 요청
2. `Service`에서 다음 로직들로 처리
      - `Redis`에 저장된 `OwnerInVerification` 객체의 아래 여부를 검증
        - 이메일에 해당하는 객체 존재 여부
        - 만료기간 만료 여부
        - 이미 인증을 완료했는지 여부
        - **인증 번호 일치 여부**
      - `Redis `객체에 인증 여부를 `True`로 변경하여 저장
3. `Controller`에서 `EmptyResponse`(`200`) 응답

- - -

**용어 정의**
- Verify: 검증의 전 과정
- Validate:  검증의 일부 과정
- Certificate: 검증의 마지막 과정 (확인 과정)

참고: [guide-to-verification_validation_certification](https://www.nweurope.eu/media/9617/guide-to-verification_validation_certification.pdf)
