### PR TITLE
Task: 사장님 전용 메뉴 카테고리 API

### DIFF
--- a/src/main/java/koreatech/in/controller/OwnerShopController.java
+++ b/src/main/java/koreatech/in/controller/OwnerShopController.java
@@ -6,6 +6,7 @@ import koreatech.in.annotation.ParamValid;
 import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
 import koreatech.in.dto.normal.shop.request.CreateMenuCategoryRequest;
+import koreatech.in.dto.normal.shop.response.AllMenuCategoriesOfShopResponse;
 import koreatech.in.service.OwnerShopService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -44,5 +45,20 @@ public class OwnerShopController {
             @ApiParam(name = "메뉴 카테고리 정보 JSON", required = true) @RequestBody @Valid CreateMenuCategoryRequest request, BindingResult bindingResult) {
         ownerShopService.createMenuCategory(shopId, request);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @ApiOperation(value = "특정 상점의 모든 메뉴 카테고리 조회", authorizations = {@Authorization("Authorization")})
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
+                                               "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
+                                               "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
+            @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message = "- 상점이 존재하지 않을 때 (code: 104000)", response = ExceptionResponse.class)
+    })
+    @RequestMapping(value = "{id}/menus/categories", method = RequestMethod.GET)
+    public @ResponseBody
+    ResponseEntity<AllMenuCategoriesOfShopResponse> getAllMenuCategoriesOfShop(@ApiParam(name = "상점 고유 id", required = true) @PathVariable("id") Integer shopId) {
+        AllMenuCategoriesOfShopResponse response = ownerShopService.getAllMenuCategoriesOfShop(shopId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerShopController.java
+++ b/src/main/java/koreatech/in/controller/OwnerShopController.java
@@ -1,0 +1,11 @@
+package koreatech.in.controller;
+
+import io.swagger.annotations.Api;
+import org.springframework.stereotype.Controller;
+
+@Api(tags = "(Normal) Owner's Shop", description = "상점 (사장님 전용)")
+@Controller
+public class OwnerShopController {
+
+
+}

--- a/src/main/java/koreatech/in/controller/OwnerShopController.java
+++ b/src/main/java/koreatech/in/controller/OwnerShopController.java
@@ -18,14 +18,14 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 @Auth(role = Auth.Role.OWNER, authority = Auth.Authority.SHOP)
-@Api(tags = "(Normal) Owner Shop", description = "상점 (사장님 전용)")
+@Api(tags = "(Normal) Owner Shop", description = "상점 (점주 전용)")
 @Controller
 @RequestMapping("/owner/shops")
 public class OwnerShopController {
     @Autowired
     private OwnerShopService ownerShopService;
 
-    @ApiOperation(value = "메뉴 카테고리 생성", notes = "한 상점당 최대 20개까지 등록 가능", authorizations = {@Authorization("Authorization")})
+    @ApiOperation(value = "상점에 메뉴 카테고리 생성", notes = "인증 정보에 대한 신원이 상점의 점주가 아니라면 403(Forbidden) 응답", authorizations = {@Authorization("Authorization")})
     @ApiResponses({
             @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
                                                "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
@@ -41,13 +41,13 @@ public class OwnerShopController {
     @RequestMapping(value = "/{id}/menus/categories", method = RequestMethod.POST)
     public @ResponseBody
     ResponseEntity<EmptyResponse> createMenuCategory(
-            @ApiParam(name = "상점 고유 id", required = true) @PathVariable("id") Integer shopId,
+            @ApiParam(required = true) @PathVariable("id") Integer shopId,
             @ApiParam(name = "메뉴 카테고리 정보 JSON", required = true) @RequestBody @Valid CreateMenuCategoryRequest request, BindingResult bindingResult) {
         ownerShopService.createMenuCategory(shopId, request);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
-    @ApiOperation(value = "상점의 모든 메뉴 카테고리 조회", authorizations = {@Authorization("Authorization")})
+    @ApiOperation(value = "상점의 모든 메뉴 카테고리 조회", notes = "인증 정보에 대한 신원이 상점의 점주가 아니라면 403(Forbidden) 응답", authorizations = {@Authorization("Authorization")})
     @ApiResponses({
             @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
                                                "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
@@ -55,14 +55,14 @@ public class OwnerShopController {
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 404, message = "- 상점이 존재하지 않을 때 (code: 104000)", response = ExceptionResponse.class)
     })
-    @RequestMapping(value = "{id}/menus/categories", method = RequestMethod.GET)
+    @RequestMapping(value = "/{id}/menus/categories", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity<AllMenuCategoriesOfShopResponse> getAllMenuCategoriesOfShop(@ApiParam(name = "상점 고유 id", required = true) @PathVariable("id") Integer shopId) {
+    ResponseEntity<AllMenuCategoriesOfShopResponse> getAllMenuCategoriesOfShop(@ApiParam(required = true) @PathVariable("id") Integer shopId) {
         AllMenuCategoriesOfShopResponse response = ownerShopService.getAllMenuCategoriesOfShop(shopId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @ApiOperation(value = "상점의 메뉴 카테고리 삭제", authorizations = {@Authorization("Authorization")})
+    @ApiOperation(value = "상점의 메뉴 카테고리 삭제", notes = "인증 정보에 대한 신원이 상점의 점주가 아니라면 403(Forbidden) 응답", authorizations = {@Authorization("Authorization")})
     @ApiResponses({
             @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
                                                "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
@@ -73,11 +73,11 @@ public class OwnerShopController {
                                                "  - 만약 categoryId에 대한 카테고리가, shopId에 대한 상점에 속해있는 카테고리가 아닌 경우도 포함", response = ExceptionResponse.class),
             @ApiResponse(code = 409, message = "- 해당 카테고리를 사용하고 있는 메뉴가 존재하여 삭제할 수 없는 경우 (code: 104012)", response = ExceptionResponse.class)
     })
-    @RequestMapping(value = "{shopId}/menus/categories/{categoryId}", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/{shopId}/menus/categories/{categoryId}", method = RequestMethod.DELETE)
     public @ResponseBody
     ResponseEntity<EmptyResponse> deleteMenuCategory(
-            @ApiParam(name = "상점 고유 id", required = true) @PathVariable("shopId") Integer shopId,
-            @ApiParam(name = "메뉴 카테고리 고유 id", required = true) @PathVariable("categoryId") Integer menuCategoryId) {
+            @ApiParam(required = true) @PathVariable("shopId") Integer shopId,
+            @ApiParam(required = true) @PathVariable("categoryId") Integer menuCategoryId) {
         ownerShopService.deleteMenuCategory(shopId, menuCategoryId);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/koreatech/in/controller/OwnerShopController.java
+++ b/src/main/java/koreatech/in/controller/OwnerShopController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 
 @Auth(role = Auth.Role.OWNER, authority = Auth.Authority.SHOP)
-@Api(tags = "(Normal) Owner's Shop", description = "상점 (사장님 전용)")
+@Api(tags = "(Normal) Owner Shop", description = "상점 (사장님 전용)")
 @Controller
 @RequestMapping("/owner/shops")
 public class OwnerShopController {
@@ -47,7 +47,7 @@ public class OwnerShopController {
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
-    @ApiOperation(value = "특정 상점의 모든 메뉴 카테고리 조회", authorizations = {@Authorization("Authorization")})
+    @ApiOperation(value = "상점의 모든 메뉴 카테고리 조회", authorizations = {@Authorization("Authorization")})
     @ApiResponses({
             @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
                                                "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
@@ -60,5 +60,25 @@ public class OwnerShopController {
     ResponseEntity<AllMenuCategoriesOfShopResponse> getAllMenuCategoriesOfShop(@ApiParam(name = "상점 고유 id", required = true) @PathVariable("id") Integer shopId) {
         AllMenuCategoriesOfShopResponse response = ownerShopService.getAllMenuCategoriesOfShop(shopId);
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "상점의 메뉴 카테고리 삭제", authorizations = {@Authorization("Authorization")})
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
+                                               "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
+                                               "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
+            @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message = "- 상점이 존재하지 않을 때 (code: 104000) \n" +
+                                               "- 메뉴 카테고리가 존재하지 않을 때 (code: 104010) \n" +
+                                               "  - 만약 categoryId에 대한 카테고리가, shopId에 대한 상점에 속해있는 카테고리가 아닌 경우도 포함", response = ExceptionResponse.class),
+            @ApiResponse(code = 409, message = "- 해당 카테고리를 사용하고 있는 메뉴가 존재하여 삭제할 수 없는 경우 (code: 104012)", response = ExceptionResponse.class)
+    })
+    @RequestMapping(value = "{shopId}/menus/categories/{categoryId}", method = RequestMethod.DELETE)
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> deleteMenuCategory(
+            @ApiParam(name = "상점 고유 id", required = true) @PathVariable("shopId") Integer shopId,
+            @ApiParam(name = "메뉴 카테고리 고유 id", required = true) @PathVariable("categoryId") Integer menuCategoryId) {
+        ownerShopService.deleteMenuCategory(shopId, menuCategoryId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerShopController.java
+++ b/src/main/java/koreatech/in/controller/OwnerShopController.java
@@ -1,11 +1,48 @@
 package koreatech.in.controller;
 
-import io.swagger.annotations.Api;
+import io.swagger.annotations.*;
+import koreatech.in.annotation.Auth;
+import koreatech.in.annotation.ParamValid;
+import koreatech.in.dto.EmptyResponse;
+import koreatech.in.dto.ExceptionResponse;
+import koreatech.in.dto.normal.shop.request.CreateMenuCategoryRequest;
+import koreatech.in.service.OwnerShopService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
+@Auth(role = Auth.Role.OWNER, authority = Auth.Authority.SHOP)
 @Api(tags = "(Normal) Owner's Shop", description = "상점 (사장님 전용)")
 @Controller
+@RequestMapping("/owner/shops")
 public class OwnerShopController {
+    @Autowired
+    private OwnerShopService ownerShopService;
 
-
+    @ApiOperation(value = "메뉴 카테고리 생성", notes = "한 상점당 최대 20개까지 등록 가능", authorizations = {@Authorization("Authorization")})
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
+                                               "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
+                                               "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
+            @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message = "- 상점이 존재하지 않을 때 (code: 104000)", response = ExceptionResponse.class),
+            @ApiResponse(code = 409, message = "- 해당 상점에 중복되는 이름의 메뉴 카테고리가 이미 존재할 때 (code: 104011) \n" +
+                                               "- 한 상점당 등록할 수 있는 메뉴 카테고리의 최대 개수(20)를 초과하였을 때 (code: 104013)", response = ExceptionResponse.class),
+            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건을 위반하였을 때 (code: 100000)", response = ExceptionResponse.class)
+    })
+    @ResponseStatus(HttpStatus.CREATED)
+    @ParamValid
+    @RequestMapping(value = "/{id}/menus/categories", method = RequestMethod.POST)
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> createMenuCategory(
+            @ApiParam(name = "상점 고유 id", required = true) @PathVariable("id") Integer shopId,
+            @ApiParam(name = "메뉴 카테고리 정보 JSON", required = true) @RequestBody @Valid CreateMenuCategoryRequest request, BindingResult bindingResult) {
+        ownerShopService.createMenuCategory(shopId, request);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
 }

--- a/src/main/java/koreatech/in/domain/Shop/Shop.java
+++ b/src/main/java/koreatech/in/domain/Shop/Shop.java
@@ -55,6 +55,14 @@ public class Shop {
         this.chosung = this.internal_name.substring(0, 1);
     }
 
+    public boolean hasSameOwnerId(Integer ownerId) {
+        if (this.owner_id == null) {
+            return false;
+        }
+
+        return this.owner_id.equals(ownerId);
+    }
+
     public boolean isDeleted() {
         if (this.is_deleted == null) {
             return false;

--- a/src/main/java/koreatech/in/dto/normal/shop/request/CreateMenuCategoryRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/request/CreateMenuCategoryRequest.java
@@ -1,0 +1,18 @@
+package koreatech.in.dto.normal.shop.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Getter @Setter
+public class CreateMenuCategoryRequest {
+    @Size(min = 1, max = 15, message = "name은 1자 이상 15자 이하입니다.")
+    @NotNull(message = "name은 필수입니다.")
+    @ApiModelProperty(notes = "카테고리명 \n" +
+                              "- not null \n" +
+                              "- 1자 이상 15자 이하", example = "사이드 메뉴", required = true)
+    private String name;
+}

--- a/src/main/java/koreatech/in/dto/normal/shop/response/AllMenuCategoriesOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/response/AllMenuCategoriesOfShopResponse.java
@@ -1,4 +1,4 @@
-package koreatech.in.dto.admin.shop.response;
+package koreatech.in.dto.normal.shop.response;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -9,12 +9,7 @@ import lombok.Getter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/**
- *   특정 상점의 모든 메뉴 카테고리를 응답
- */
-
 @Getter @Builder
-@ApiModel("AdminAllMenuCategoriesOfShopResponse")
 public class AllMenuCategoriesOfShopResponse {
     @ApiModelProperty(notes = "개수", example = "4", required = true)
     private Integer count;
@@ -22,8 +17,8 @@ public class AllMenuCategoriesOfShopResponse {
     @ApiModelProperty(notes = "메뉴 카테고리 리스트", required = true)
     private List<Category> menu_categories;
 
-    @Getter @Builder
-    @ApiModel("Category_2")
+    @Getter
+    @ApiModel("Category_3")
     private static class Category {
         @ApiModelProperty(notes = "카테고리 고유 id", required = true)
         private Integer id;

--- a/src/main/java/koreatech/in/repository/ShopMapper.java
+++ b/src/main/java/koreatech/in/repository/ShopMapper.java
@@ -15,4 +15,13 @@ public interface ShopMapper {
     List<ShopProfile> getAllShopProfiles();
 
     List<ShopMenuProfile> getMenuProfilesByShopId(@Param("shopId") Integer shopId);
+
+
+    Shop getShopById(@Param("id") Integer id);
+
+    ShopMenuCategory getMenuCategoryByShopIdAndName(@Param("shopId") Integer shopId, @Param("name") String name);
+
+    Integer getCountOfMenuCategoriesByShopId(@Param("shopId") Integer shopId);
+
+    void createMenuCategory(@Param("menuCategory") ShopMenuCategory menuCategory);
 }

--- a/src/main/java/koreatech/in/repository/ShopMapper.java
+++ b/src/main/java/koreatech/in/repository/ShopMapper.java
@@ -24,4 +24,6 @@ public interface ShopMapper {
     Integer getCountOfMenuCategoriesByShopId(@Param("shopId") Integer shopId);
 
     void createMenuCategory(@Param("menuCategory") ShopMenuCategory menuCategory);
+
+    List<ShopMenuCategory> getMenuCategoriesByShopId(@Param("shopId") Integer shopId);
 }

--- a/src/main/java/koreatech/in/repository/ShopMapper.java
+++ b/src/main/java/koreatech/in/repository/ShopMapper.java
@@ -16,7 +16,6 @@ public interface ShopMapper {
 
     List<ShopMenuProfile> getMenuProfilesByShopId(@Param("shopId") Integer shopId);
 
-
     Shop getShopById(@Param("id") Integer id);
 
     ShopMenuCategory getMenuCategoryByShopIdAndName(@Param("shopId") Integer shopId, @Param("name") String name);
@@ -26,4 +25,10 @@ public interface ShopMapper {
     void createMenuCategory(@Param("menuCategory") ShopMenuCategory menuCategory);
 
     List<ShopMenuCategory> getMenuCategoriesByShopId(@Param("shopId") Integer shopId);
+
+    ShopMenuCategory getMenuCategoryById(@Param("id") Integer id);
+
+    List<ShopMenu> getMenusUsingCategoryByMenuCategoryId(@Param("menuCategoryId") Integer menuCategoryId);
+
+    void deleteMenuCategoryById(@Param("id") Integer id);
 }

--- a/src/main/java/koreatech/in/service/OwnerShopService.java
+++ b/src/main/java/koreatech/in/service/OwnerShopService.java
@@ -1,7 +1,10 @@
 package koreatech.in.service;
 
 import koreatech.in.dto.normal.shop.request.CreateMenuCategoryRequest;
+import koreatech.in.dto.normal.shop.response.AllMenuCategoriesOfShopResponse;
 
 public interface OwnerShopService {
     void createMenuCategory(Integer shopId, CreateMenuCategoryRequest request);
+
+    AllMenuCategoriesOfShopResponse getAllMenuCategoriesOfShop(Integer shopId);
 }

--- a/src/main/java/koreatech/in/service/OwnerShopService.java
+++ b/src/main/java/koreatech/in/service/OwnerShopService.java
@@ -1,4 +1,7 @@
 package koreatech.in.service;
 
+import koreatech.in.dto.normal.shop.request.CreateMenuCategoryRequest;
+
 public interface OwnerShopService {
+    void createMenuCategory(Integer shopId, CreateMenuCategoryRequest request);
 }

--- a/src/main/java/koreatech/in/service/OwnerShopService.java
+++ b/src/main/java/koreatech/in/service/OwnerShopService.java
@@ -1,0 +1,4 @@
+package koreatech.in.service;
+
+public interface OwnerShopService {
+}

--- a/src/main/java/koreatech/in/service/OwnerShopService.java
+++ b/src/main/java/koreatech/in/service/OwnerShopService.java
@@ -7,4 +7,6 @@ public interface OwnerShopService {
     void createMenuCategory(Integer shopId, CreateMenuCategoryRequest request);
 
     AllMenuCategoriesOfShopResponse getAllMenuCategoriesOfShop(Integer shopId);
+
+    void deleteMenuCategory(Integer shopId, Integer menuCategoryId);
 }

--- a/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
@@ -1,7 +1,73 @@
 package koreatech.in.service;
 
+import koreatech.in.domain.Shop.Shop;
+import koreatech.in.domain.Shop.ShopMenuCategory;
+import koreatech.in.domain.User.owner.Owner;
+import koreatech.in.dto.normal.shop.request.CreateMenuCategoryRequest;
+import koreatech.in.exception.BaseException;
+import koreatech.in.repository.ShopMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static koreatech.in.exception.ExceptionInformation.*;
 
 @Service
 public class OwnerShopServiceImpl implements OwnerShopService {
+    @Autowired
+    private JwtValidator jwtValidator;
+
+    @Autowired
+    private ShopMapper shopMapper;
+
+    @Override
+    public void createMenuCategory(Integer shopId, CreateMenuCategoryRequest request) {
+        Shop shop = getShopById(shopId);
+        
+        checkAuthorityAboutShop(shop);
+
+        checkMenuCategoryNameDuplicationAtSameShop(shopId, request.getName());
+        checkExceedsMaximumCountOfMenuCategoriesAtShop(shopId);
+
+        ShopMenuCategory menuCategory = ShopMenuCategory.of(shopId, request.getName());
+        shopMapper.createMenuCategory(menuCategory);
+    }
+
+    private void checkExceedsMaximumCountOfMenuCategoriesAtShop(Integer shopId) {
+        Integer existingCount = shopMapper.getCountOfMenuCategoriesByShopId(shopId);
+        if (existingCount.equals(20)) {
+            throw new BaseException(SHOP_MENU_CATEGORY_MAXIMUM_EXCEED);
+        }
+    }
+
+    private void checkMenuCategoryNameDuplicationAtSameShop(Integer shopId, String name) {
+        Optional.ofNullable(shopMapper.getMenuCategoryByShopIdAndName(shopId, name))
+                .ifPresent(menuCategory -> {
+                    throw new BaseException(SHOP_MENU_CATEGORY_NAME_DUPLICATE);
+                });
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+    private Shop getShopById(Integer id) {
+        return Optional.ofNullable(shopMapper.getShopById(id))
+                .orElseThrow(() -> new BaseException(SHOP_NOT_FOUND));
+    }
+
+    private void checkAuthorityAboutShop(Shop shop) {
+        Owner owner = (Owner) jwtValidator.validate();
+        if (!shop.hasSameOwnerId(owner.getId())) {
+            throw new BaseException(FORBIDDEN);
+        }
+    }
 }

--- a/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
@@ -4,16 +4,20 @@ import koreatech.in.domain.Shop.Shop;
 import koreatech.in.domain.Shop.ShopMenuCategory;
 import koreatech.in.domain.User.owner.Owner;
 import koreatech.in.dto.normal.shop.request.CreateMenuCategoryRequest;
+import koreatech.in.dto.normal.shop.response.AllMenuCategoriesOfShopResponse;
 import koreatech.in.exception.BaseException;
 import koreatech.in.repository.ShopMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static koreatech.in.exception.ExceptionInformation.*;
 
 @Service
+@Transactional(readOnly = true)
 public class OwnerShopServiceImpl implements OwnerShopService {
     @Autowired
     private JwtValidator jwtValidator;
@@ -23,15 +27,22 @@ public class OwnerShopServiceImpl implements OwnerShopService {
 
     @Override
     public void createMenuCategory(Integer shopId, CreateMenuCategoryRequest request) {
-        Shop shop = getShopById(shopId);
-        
-        checkAuthorityAboutShop(shop);
+        checkAuthorityAboutShop(getShopById(shopId));
 
         checkMenuCategoryNameDuplicationAtSameShop(shopId, request.getName());
         checkExceedsMaximumCountOfMenuCategoriesAtShop(shopId);
 
         ShopMenuCategory menuCategory = ShopMenuCategory.of(shopId, request.getName());
         shopMapper.createMenuCategory(menuCategory);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AllMenuCategoriesOfShopResponse getAllMenuCategoriesOfShop(Integer shopId) {
+        checkAuthorityAboutShop(getShopById(shopId));
+
+        List<ShopMenuCategory> allMenuCategoriesOfShop = shopMapper.getMenuCategoriesByShopId(shopId);
+        return AllMenuCategoriesOfShopResponse.from(allMenuCategoriesOfShop);
     }
 
     private void checkExceedsMaximumCountOfMenuCategoriesAtShop(Integer shopId) {

--- a/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
@@ -1,0 +1,7 @@
+package koreatech.in.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class OwnerShopServiceImpl implements OwnerShopService {
+}

--- a/src/main/resources/mapper/normal/ShopMapper.xml
+++ b/src/main/resources/mapper/normal/ShopMapper.xml
@@ -232,6 +232,14 @@
         )
     </insert>
 
+    <select id="getMenuCategoriesByShopId" parameterType="integer" resultType="koreatech.in.domain.Shop.ShopMenuCategory">
+        SELECT *
+        FROM `koin`.`shop_menu_categories`
+        WHERE
+            `shop_id` = #{shopId}
+            AND `is_deleted` = 0
+    </select>
+
 
     <resultMap id="ShopProfile" type="koreatech.in.domain.Shop.ShopProfile">
         <id property="id" column="shops.id"/>

--- a/src/main/resources/mapper/normal/ShopMapper.xml
+++ b/src/main/resources/mapper/normal/ShopMapper.xml
@@ -195,6 +195,44 @@
                 AND `t5`.`is_deleted` = 0
     </select>
 
+
+    <select id="getShopById" parameterType="integer" resultType="koreatech.in.domain.Shop.Shop">
+        SELECT *
+        FROM `koin`.`shops`
+        WHERE
+            `id` = #{id}
+            AND `is_deleted` = 0
+    </select>
+
+    <select id="getMenuCategoryByShopIdAndName" resultType="koreatech.in.domain.Shop.ShopMenuCategory">
+        SELECT *
+        FROM `koin`.`shop_menu_categories`
+        WHERE
+            `shop_id` = #{shopId}
+            AND `name` = #{name}
+            AND `is_deleted` = 0
+    </select>
+
+    <select id="getCountOfMenuCategoriesByShopId" resultType="integer">
+        SELECT COUNT(*)
+        FROM `koin`.`shop_menu_categories`
+        WHERE
+            `shop_id` = #{shopId}
+             AND `is_deleted` = 0
+    </select>
+
+    <insert id="createMenuCategory" parameterType="koreatech.in.domain.Shop.ShopMenuCategory" keyProperty="menuCategory.id">
+        INSERT INTO `koin`.`shop_menu_categories` (
+            `shop_id`,
+            `name`
+        )
+        VALUES (
+            #{menuCategory.shop_id},
+            #{menuCategory.name}
+        )
+    </insert>
+
+
     <resultMap id="ShopProfile" type="koreatech.in.domain.Shop.ShopProfile">
         <id property="id" column="shops.id"/>
         <result property="name" column="shops.name"/>

--- a/src/main/resources/mapper/normal/ShopMapper.xml
+++ b/src/main/resources/mapper/normal/ShopMapper.xml
@@ -240,6 +240,33 @@
             AND `is_deleted` = 0
     </select>
 
+    <select id="getMenuCategoryById" parameterType="integer" resultType="koreatech.in.domain.Shop.ShopMenuCategory">
+        SELECT *
+        FROM `koin`.`shop_menu_categories`
+        WHERE
+            `id` = #{id}
+            AND `is_deleted` = 0
+    </select>
+
+    <select id="getMenusUsingCategoryByMenuCategoryId" parameterType="integer" resultType="koreatech.in.domain.Shop.ShopMenu">
+        SELECT *
+        FROM `koin`.`shop_menus`
+        WHERE
+            `id` IN (
+                SELECT `shop_menu_id`
+                FROM `koin`.`shop_menu_category_map`
+                WHERE
+                    `shop_menu_category_id` = #{menuCategoryId}
+            )
+            AND `is_deleted` = 0
+    </select>
+
+    <update id="deleteMenuCategoryById" parameterType="integer">
+        UPDATE `koin`.`shop_menu_categories`
+        SET `is_deleted` = 1
+        WHERE `id` = #{id}
+    </update>
+
 
     <resultMap id="ShopProfile" type="koreatech.in.domain.Shop.ShopProfile">
         <id property="id" column="shops.id"/>


### PR DESCRIPTION
### UI에 따른 API 작성
<img width="288" alt="image" src="https://user-images.githubusercontent.com/56067949/217014091-b7a6a87a-ee62-4c98-819c-b0861a43693c.png">

- 메뉴 카테고리 생성
- 특정 상점의 모든 메뉴 카테고리 조회
- 메뉴 카테고리 삭제

- 어드민 상점 API와 로직은 거의 유사하고, 유저의 신원이 상점의 점주와 같은지 확인하는 프로세스 추가