### PR TITLE
Refactor: 422 응답에 대한 처리방식 및 스키마 변경

### DIFF
--- a/src/main/java/koreatech/in/aop/ValidParameters.java
+++ b/src/main/java/koreatech/in/aop/ValidParameters.java
@@ -7,7 +7,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.ObjectError;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/koreatech/in/aop/ValidParameters.java
+++ b/src/main/java/koreatech/in/aop/ValidParameters.java
@@ -1,34 +1,32 @@
 package koreatech.in.aop;
 
-import koreatech.in.domain.ErrorMessage;
-import koreatech.in.exception.ValidationException;
+import koreatech.in.exception.RequestDataInvalidException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @Aspect
 public class ValidParameters {
     @Around(value = "@annotation(koreatech.in.annotation.ParamValid)")
-
     public Object validateBean(ProceedingJoinPoint joinPoint) throws Throwable {
         Object[] args = joinPoint.getArgs();
         for (Object arg : args) {
             if (arg instanceof BindingResult) {
                 BindingResult result = (BindingResult) arg;
                 if (result.hasErrors()) {
-                    List<ObjectError> list = result.getAllErrors();
-                    StringBuilder errorMessage = new StringBuilder();
-                    for (ObjectError e : list) {
-                        errorMessage.append(String.format("%s\n", e.getDefaultMessage()));
-                    }
-//                    System.out.println(errorMessage);
-                    throw new ValidationException(new ErrorMessage(errorMessage.toString(), 0));
+                    List<String> violations = result.getAllErrors().stream()
+                            .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                            .collect(Collectors.toList());
+
+                    throw new RequestDataInvalidException(violations);
                 }
                 break;
             }

--- a/src/main/java/koreatech/in/controller/GlobalExceptionHandler.java
+++ b/src/main/java/koreatech/in/controller/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package koreatech.in.controller;
 
 import koreatech.in.dto.ExceptionResponse;
+import koreatech.in.dto.RequestDataInvalidResponse;
 import koreatech.in.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -60,9 +61,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ExceptionResponse.of(e.getErrorCode(), e.getMessage()), e.getHttpStatus());
     }
 
-//    @ExceptionHandler(value = Exception.class)
-//    public String handleException(Exception e){
-//        System.out.println("global server error except handle");
-//        return e.getMessage();
-//    }
+    @ExceptionHandler(RequestDataInvalidException.class)
+    public @ResponseBody
+    ResponseEntity<RequestDataInvalidResponse> RequestDataInvalidException(RequestDataInvalidException e) {
+        return new ResponseEntity<>(RequestDataInvalidResponse.of(e.getErrorCode(), e.getMessage(), e.getViolations()), e.getHttpStatus());
+    }
 }

--- a/src/main/java/koreatech/in/controller/GlobalExceptionHandler.java
+++ b/src/main/java/koreatech/in/controller/GlobalExceptionHandler.java
@@ -9,7 +9,10 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.Map;
+import java.util.*;
+
+import static koreatech.in.exception.ExceptionInformation.REQUEST_DATA_INVALID;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -52,15 +55,27 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ValidationException.class)
     public @ResponseBody
     ResponseEntity ValidationException(ValidationException e) {
-        return new ResponseEntity<Map<String, Object>>(e.getErrorMessage().getMap(), HttpStatus.UNPROCESSABLE_ENTITY);
+        return new ResponseEntity<Map<String, Object>>(e.getErrorMessage().getMap(), UNPROCESSABLE_ENTITY);
     }
 
     @ExceptionHandler(BaseException.class)
     public @ResponseBody
     ResponseEntity<ExceptionResponse> BaseException(BaseException e) {
+        HttpStatus httpStatus = e.getHttpStatus();
+        if (httpStatus.equals(UNPROCESSABLE_ENTITY)) {
+            return new ResponseEntity<>(RequestDataInvalidResponse.of(
+                    REQUEST_DATA_INVALID.getCode(),
+                    REQUEST_DATA_INVALID.getMessage(),
+                    Collections.singletonList(e.getMessage())
+            ),
+                    REQUEST_DATA_INVALID.getHttpStatus()
+            );
+        }
+
         return new ResponseEntity<>(ExceptionResponse.of(e.getErrorCode(), e.getMessage()), e.getHttpStatus());
     }
 
+    // ValidParameters AOP에서 throw
     @ExceptionHandler(RequestDataInvalidException.class)
     public @ResponseBody
     ResponseEntity<RequestDataInvalidResponse> RequestDataInvalidException(RequestDataInvalidException e) {

--- a/src/main/java/koreatech/in/controller/admin/AdminLandController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminLandController.java
@@ -34,7 +34,7 @@ public class AdminLandController {
                                                "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 409, message = "- 이름이 중복될 때 (code: 107001)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @ParamValid
     @RequestMapping(value = "/admin/lands", method = RequestMethod.POST)
@@ -70,7 +70,7 @@ public class AdminLandController {
                                                "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 404, message = "- 유효하지 않은 페이지일 때 (code: 100002)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @RequestMapping(value = "/admin/lands", method = RequestMethod.GET)
     public @ResponseBody
@@ -89,7 +89,7 @@ public class AdminLandController {
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 404, message = "- 존재하지 않는 집일 때 (code: 107000)", response = ExceptionResponse.class),
             @ApiResponse(code = 409, message = "- 이름이 중복될 때 (code: 107001)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @ParamValid
     @RequestMapping(value = "/admin/lands/{id}", method = RequestMethod.PUT)

--- a/src/main/java/koreatech/in/controller/admin/AdminMemberController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminMemberController.java
@@ -5,6 +5,7 @@ import koreatech.in.annotation.Auth;
 import koreatech.in.annotation.ParamValid;
 import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
+import koreatech.in.dto.RequestDataInvalidResponse;
 import koreatech.in.dto.admin.member.request.CreateMemberRequest;
 import koreatech.in.dto.admin.member.request.MembersCondition;
 import koreatech.in.dto.admin.member.request.UpdateMemberRequest;
@@ -35,7 +36,7 @@ public class AdminMemberController {
                                                "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 404, message = "- 요청한 트랙이 조회되지 않을 때 (error code: 201000)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @ParamValid
     @RequestMapping(value = "/admin/members", method = RequestMethod.POST)
@@ -67,7 +68,7 @@ public class AdminMemberController {
                                                "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 404, message = "- 유효하지 않은 페이지일 때 (error code: 100002)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @RequestMapping(value = "/admin/members", method = RequestMethod.GET)
     public @ResponseBody
@@ -86,7 +87,7 @@ public class AdminMemberController {
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 404, message = "- 회원이 존재하지 않을 때 (error code: 202000) \n\n" +
                                                "- 요청한 트랙이 조회되지 않을 때 (error code: 201000)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @ParamValid
     @RequestMapping(value = "/admin/members/{id}", method = RequestMethod.PUT)

--- a/src/main/java/koreatech/in/dto/RequestDataInvalidResponse.java
+++ b/src/main/java/koreatech/in/dto/RequestDataInvalidResponse.java
@@ -1,0 +1,20 @@
+package koreatech.in.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class RequestDataInvalidResponse {
+    @ApiModelProperty(notes = "에러 코드", required = true)
+    private Integer code;
+    @ApiModelProperty(notes = "에러 메시지", required = true)
+    private List<String> message;
+
+    public RequestDataInvalidResponse of(Integer code, List<String> message) {
+        return new RequestDataInvalidResponse(code, message);
+    }
+}

--- a/src/main/java/koreatech/in/dto/RequestDataInvalidResponse.java
+++ b/src/main/java/koreatech/in/dto/RequestDataInvalidResponse.java
@@ -1,20 +1,19 @@
 package koreatech.in.dto;
 
-import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
-public class RequestDataInvalidResponse {
-    @ApiModelProperty(notes = "에러 코드", required = true)
-    private Integer code;
-    @ApiModelProperty(notes = "에러 메시지", required = true)
-    private List<String> message;
+public class RequestDataInvalidResponse extends ExceptionResponse {
+    private final List<String> violations;
 
-    public RequestDataInvalidResponse of(Integer code, List<String> message) {
-        return new RequestDataInvalidResponse(code, message);
+    private RequestDataInvalidResponse(Integer code, String message, List<String> violations) {
+        super(code, message);
+        this.violations = violations;
+    }
+
+    public static RequestDataInvalidResponse of(Integer code, String message, List<String> violations) {
+        return new RequestDataInvalidResponse(code, message, violations);
     }
 }

--- a/src/main/java/koreatech/in/dto/admin/land/request/CreateLandRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/land/request/CreateLandRequest.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 @Getter @Setter
 public class CreateLandRequest {
-    @NotNull(message = "name은 필수입니다.")
-    @Size(max = 255, message = "name의 최대 길이는 255자 입니다.")
+    @NotNull(message = "방이름은 필수입니다.")
+    @Size(max = 255, message = "방이름의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "이름 \n" +
                               "- not null \n" +
                               "- 최대 255자", example = "금실타운", required = true)
@@ -23,7 +23,7 @@ public class CreateLandRequest {
     @ApiModelProperty(notes = "크기", example = "9.0")
     private Double size;
 
-    @Size(max = 20, message = "room_type의 최대 길이는 20자 입니다.")
+    @Size(max = 20, message = "방종류의 최대 길이는 20자입니다.")
     @ApiModelProperty(notes = "종류 \n" +
                               "- 최대 20자", example = "원룸")
     private String room_type;
@@ -34,7 +34,7 @@ public class CreateLandRequest {
     @ApiModelProperty(notes = "경도", example = "127.284638")
     private Double longitude;
 
-    @Pattern(regexp = "^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$", message = "phone의 정규식은 ^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$ 입니다.")
+    @Pattern(regexp = "^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$", message = "전화번호의 형식이 올바르지 않습니다.")
     @ApiModelProperty(notes = "전화번호 \n" +
                               "- 정규식 `^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$` 을 만족해야함", example = "041-111-1111")
     private String phone;
@@ -42,37 +42,37 @@ public class CreateLandRequest {
     @ApiModelProperty(notes = "이미지 url 리스트")
     private List<String> image_urls = new ArrayList<>();
 
-    @Size(max = 65535, message = "address의 최대 길이는 65535자 입니다.")
+    @Size(max = 65535, message = "주소의 최대 길이는 65535자입니다.")
     @ApiModelProperty(notes = "주소 \n" +
                               "- 최대 65535자", example = "충청남도 천안시 동남구 병천면")
     private String address;
 
-    @Size(max = 65535, message = "description의 최대 길이는 65535자 입니다.")
+    @Size(max = 65535, message = "설명의 최대 길이는 65535자입니다.")
     @ApiModelProperty(notes = "설명 \n" +
                               "- 최대 65535자", example = "1년 계약시 20만원 할인")
     private String description;
 
-    @PositiveOrZero(message = "floor은 0 이상이어야 합니다.")
+    @PositiveOrZero(message = "층수는 0 이상이어야합니다.")
     @ApiModelProperty(notes = "층수 \n" +
                               "- 음수 불가능", example = "4")
     private Integer floor;
 
-    @Size(max = 255, message = "deposit의 최대 길이는 255자 입니다.")
+    @Size(max = 255, message = "보증금의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "보증금 \n" +
                               "- 최대 255자", example = "30")
     private String deposit;
 
-    @Size(max = 255, message = "monthly_fee의 최대 길이는 255자 입니다.")
+    @Size(max = 255, message = "월세의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "월세 \n" +
                               "- 최대 255자", example = "200만원 (6개월)")
     private String monthly_fee;
 
-    @Size(max = 20, message = "charter_fee의 최대 길이는 20자 입니다.")
+    @Size(max = 20, message = "전세의 최대 길이는 20자입니다.")
     @ApiModelProperty(notes = "전세 \n" +
                               "- 최대 20자", example = "3500")
     private String charter_fee;
 
-    @Size(max = 255, message = "management_fee의 최대 길이는 255자 입니다.")
+    @Size(max = 255, message = "관리비의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "관리비 \n" +
                               "- 최대 255자", example = "21(1인 기준)")
     private String management_fee;

--- a/src/main/java/koreatech/in/dto/admin/land/request/LandsCondition.java
+++ b/src/main/java/koreatech/in/dto/admin/land/request/LandsCondition.java
@@ -2,15 +2,13 @@ package koreatech.in.dto.admin.land.request;
 
 import io.swagger.annotations.ApiParam;
 import koreatech.in.domain.Criteria.Criteria;
-import koreatech.in.exception.BaseException;
+import koreatech.in.exception.RequestDataInvalidException;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static koreatech.in.exception.ExceptionInformation.REQUEST_DATA_INVALID;
 
 @Getter @Setter
 public class LandsCondition extends Criteria {
@@ -96,13 +94,13 @@ public class LandsCondition extends Criteria {
 
     private void checkQueryIsEmpty() {
         if (this.query.length() == 0) {
-            throw new BaseException("query의 길이는 1 이상이어야 합니다.", REQUEST_DATA_INVALID);
+            throw new RequestDataInvalidException("검색 내용의 길이는 한글자 이상이어야 합니다.");
         }
     }
 
     private void checkQueryIsBlank() {
         if (StringUtils.isBlank(this.query)) {
-            throw new BaseException("query가 공백 문자로만 이루어져 있으면 안됩니다.", REQUEST_DATA_INVALID);
+            throw new RequestDataInvalidException("검색 내용이 공백 문자로만 이루어져 있으면 안됩니다.");
         }
     }
 }

--- a/src/main/java/koreatech/in/dto/admin/land/request/LandsCondition.java
+++ b/src/main/java/koreatech/in/dto/admin/land/request/LandsCondition.java
@@ -3,8 +3,6 @@ package koreatech.in.dto.admin.land.request;
 import io.swagger.annotations.ApiParam;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.exception.BaseException;
-import koreatech.in.exception.ExceptionInformation;
-import koreatech.in.exception.RequestDataInvalidException;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/koreatech/in/dto/admin/land/request/LandsCondition.java
+++ b/src/main/java/koreatech/in/dto/admin/land/request/LandsCondition.java
@@ -2,6 +2,8 @@ package koreatech.in.dto.admin.land.request;
 
 import io.swagger.annotations.ApiParam;
 import koreatech.in.domain.Criteria.Criteria;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.exception.RequestDataInvalidException;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,6 +11,9 @@ import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static koreatech.in.exception.ExceptionInformation.SEARCH_QUERY_LENGTH_AT_LEAST_1;
+import static koreatech.in.exception.ExceptionInformation.SEARCH_QUERY_MUST_NOT_BE_BLANK;
 
 @Getter @Setter
 public class LandsCondition extends Criteria {
@@ -94,13 +99,13 @@ public class LandsCondition extends Criteria {
 
     private void checkQueryIsEmpty() {
         if (this.query.length() == 0) {
-            throw new RequestDataInvalidException("검색 내용의 길이는 한글자 이상이어야 합니다.");
+            throw new BaseException(SEARCH_QUERY_LENGTH_AT_LEAST_1);
         }
     }
 
     private void checkQueryIsBlank() {
         if (StringUtils.isBlank(this.query)) {
-            throw new RequestDataInvalidException("검색 내용이 공백 문자로만 이루어져 있으면 안됩니다.");
+            throw new BaseException(SEARCH_QUERY_MUST_NOT_BE_BLANK);
         }
     }
 }

--- a/src/main/java/koreatech/in/dto/admin/land/request/UpdateLandRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/land/request/UpdateLandRequest.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 @Getter @Setter
 public class UpdateLandRequest {
-    @NotNull(message = "name은 필수입니다.")
-    @Size(max = 255, message = "name의 최대 길이는 255자 입니다.")
+    @NotNull(message = "방이름은 필수입니다.")
+    @Size(max = 255, message = "방이름의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "이름 \n" +
             "- not null \n" +
             "- 최대 255자", example = "금실타운", required = true)
@@ -23,7 +23,7 @@ public class UpdateLandRequest {
     @ApiModelProperty(notes = "크기", example = "9.0")
     private Double size;
 
-    @Size(max = 20, message = "room_type의 최대 길이는 20자 입니다.")
+    @Size(max = 20, message = "방종류의 최대 길이는 20자입니다.")
     @ApiModelProperty(notes = "종류 \n" +
             "- 최대 20자", example = "원룸")
     private String room_type;
@@ -34,7 +34,7 @@ public class UpdateLandRequest {
     @ApiModelProperty(notes = "경도", example = "127.284638")
     private Double longitude;
 
-    @Pattern(regexp = "^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$", message = "phone의 정규식은 ^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$ 입니다.")
+    @Pattern(regexp = "^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$", message = "전화번호의 형식이 올바르지 않습니다.")
     @ApiModelProperty(notes = "전화번호 \n" +
             "- 정규식 `^[0-9]{3}-[0-9]{3,4}-[0-9]{4}$` 을 만족해야함", example = "041-111-1111")
     private String phone;
@@ -42,37 +42,37 @@ public class UpdateLandRequest {
     @ApiModelProperty(notes = "이미지 url 리스트")
     private List<String> image_urls = new ArrayList<>();
 
-    @Size(max = 65535, message = "address의 최대 길이는 65535자 입니다.")
+    @Size(max = 65535, message = "주소의 최대 길이는 65535자입니다.")
     @ApiModelProperty(notes = "주소 \n" +
             "- 최대 65535자", example = "충청남도 천안시 동남구 병천면")
     private String address;
 
-    @Size(max = 65535, message = "description의 최대 길이는 65535자 입니다.")
+    @Size(max = 65535, message = "설명의 최대 길이는 65535자입니다.")
     @ApiModelProperty(notes = "설명 \n" +
             "- 최대 65535자", example = "1년 계약시 20만원 할인")
     private String description;
 
-    @PositiveOrZero(message = "floor은 0 이상이어야 합니다.")
+    @PositiveOrZero(message = "층수는 0 이상이어야합니다.")
     @ApiModelProperty(notes = "층수 \n" +
             "- 음수 불가능", example = "4")
     private Integer floor;
 
-    @Size(max = 255, message = "deposit의 최대 길이는 255자 입니다.")
+    @Size(max = 255, message = "보증금의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "보증금 \n" +
             "- 최대 255자", example = "30")
     private String deposit;
 
-    @Size(max = 255, message = "monthly_fee의 최대 길이는 255자 입니다.")
+    @Size(max = 255, message = "월세의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "월세 \n" +
             "- 최대 255자", example = "200만원 (6개월)")
     private String monthly_fee;
 
-    @Size(max = 20, message = "charter_fee의 최대 길이는 20자 입니다.")
+    @Size(max = 20, message = "전세의 최대 길이는 20자입니다.")
     @ApiModelProperty(notes = "전세 \n" +
             "- 최대 20자", example = "3500")
     private String charter_fee;
 
-    @Size(max = 255, message = "management_fee의 최대 길이는 255자 입니다.")
+    @Size(max = 255, message = "관리비의 최대 길이는 255자입니다.")
     @ApiModelProperty(notes = "관리비 \n" +
             "- 최대 255자", example = "21(1인 기준)")
     private String management_fee;

--- a/src/main/java/koreatech/in/dto/admin/member/request/CreateMemberRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/member/request/CreateMemberRequest.java
@@ -10,40 +10,40 @@ import javax.validation.constraints.Size;
 
 @Getter @Setter
 public class CreateMemberRequest {
-    @NotNull
-    @Size(max = 50)
+    @NotNull(message = "이름은 필수입니다.")
+    @Size(max = 50, message = "이름의 길이는 최대 50자입니다.")
     @ApiModelProperty(notes = "이름 \n" +
                               "- not null \n" +
                               "- 최대 50자", example = "김주원", required = true)
     private String name;
 
-    @Size(max = 10)
+    @Size(max = 10, message = "학번의 길이는 최대 10자입니다.")
     @ApiModelProperty(notes = "학번 \n" +
                               "- 최대 10자", example = "2019136037")
     private String student_number;
 
-    @NotNull
-    @Pattern(regexp = "^(Android|BackEnd|FrontEnd|Game|UI\\/UX)$")
+    @NotNull(message = "트랙은 필수입니다.")
+    @Pattern(regexp = "^(Android|BackEnd|FrontEnd|Game|UI\\/UX)$", message = "트랙의 형식이 올바르지 않습니다.")
     @ApiModelProperty(notes = "소속 트랙 \n" +
                               "- not null \n" +
                               "- Android, BackEnd, FrontEnd, Game, UI/UX 중 택 1 " +
                               "(정규식 `^(Android|BackEnd|FrontEnd|Game|UI\\/UX)$` 을 만족해야함)", example = "BackEnd", required = true)
     private String track;
 
-    @NotNull
-    @Pattern(regexp = "^(Mentor|Regular)$")
+    @NotNull(message = "직급은 필수입니다.")
+    @Pattern(regexp = "^(Mentor|Regular)$", message = "직급의 형식이 올바르지 않습니다.")
     @ApiModelProperty(notes = "직급 \n" +
                               "- not null \n" +
                               "- Mentor 또는 Regular 중 택 1 " +
                               "(정규식 `^(Mentor|Regular)$` 을 만족해야함)", example = "Regular", required = true)
     private String position;
 
-    @Size(max = 100)
+    @Size(max = 100, message = "이메일의 길이는 최대 100자입니다.")
     @ApiModelProperty(notes = "이메일 \n" +
                               "- 최대 100자", example = "damiano102777@naver.com")
     private String email;
 
-    @Size(max = 65535)
+    @Size(max = 65535, message = "이미지 링크의 길이는 최대 65535자입니다.")
     @ApiModelProperty(notes = "이미지 링크 \n" +
                               "- 최대 65535자", example = "https://example.com")
     private String image_url;

--- a/src/main/java/koreatech/in/dto/admin/member/request/MembersCondition.java
+++ b/src/main/java/koreatech/in/dto/admin/member/request/MembersCondition.java
@@ -3,8 +3,6 @@ package koreatech.in.dto.admin.member.request;
 import io.swagger.annotations.ApiParam;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.exception.BaseException;
-import koreatech.in.exception.ExceptionInformation;
-import koreatech.in.exception.RequestDataInvalidException;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/koreatech/in/dto/admin/member/request/MembersCondition.java
+++ b/src/main/java/koreatech/in/dto/admin/member/request/MembersCondition.java
@@ -2,12 +2,10 @@ package koreatech.in.dto.admin.member.request;
 
 import io.swagger.annotations.ApiParam;
 import koreatech.in.domain.Criteria.Criteria;
-import koreatech.in.exception.BaseException;
+import koreatech.in.exception.RequestDataInvalidException;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang.StringUtils;
-
-import static koreatech.in.exception.ExceptionInformation.REQUEST_DATA_INVALID;
 
 @Getter @Setter
 public class MembersCondition extends Criteria {
@@ -83,13 +81,13 @@ public class MembersCondition extends Criteria {
 
     private void checkQueryIsEmpty() {
         if (this.query.length() == 0) {
-            throw new BaseException("query의 길이는 1 이상이어야 합니다.", REQUEST_DATA_INVALID);
+            throw new RequestDataInvalidException("검색 내용은 한글자 이상이어야 합니다.");
         }
     }
 
     private void checkQueryIsBlank() {
         if (StringUtils.isBlank(this.query)) {
-            throw new BaseException("query가 공백 문자로만 이루어져 있으면 안됩니다.", REQUEST_DATA_INVALID);
+            throw new RequestDataInvalidException("검색 내용은 공백 문자로만 이루어져 있으면 안됩니다.");
         }
     }
 }

--- a/src/main/java/koreatech/in/dto/admin/member/request/MembersCondition.java
+++ b/src/main/java/koreatech/in/dto/admin/member/request/MembersCondition.java
@@ -2,10 +2,15 @@ package koreatech.in.dto.admin.member.request;
 
 import io.swagger.annotations.ApiParam;
 import koreatech.in.domain.Criteria.Criteria;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.exception.RequestDataInvalidException;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang.StringUtils;
+
+import static koreatech.in.exception.ExceptionInformation.SEARCH_QUERY_LENGTH_AT_LEAST_1;
+import static koreatech.in.exception.ExceptionInformation.SEARCH_QUERY_MUST_NOT_BE_BLANK;
 
 @Getter @Setter
 public class MembersCondition extends Criteria {
@@ -81,13 +86,13 @@ public class MembersCondition extends Criteria {
 
     private void checkQueryIsEmpty() {
         if (this.query.length() == 0) {
-            throw new RequestDataInvalidException("검색 내용은 한글자 이상이어야 합니다.");
+            throw new BaseException(SEARCH_QUERY_LENGTH_AT_LEAST_1);
         }
     }
 
     private void checkQueryIsBlank() {
         if (StringUtils.isBlank(this.query)) {
-            throw new RequestDataInvalidException("검색 내용은 공백 문자로만 이루어져 있으면 안됩니다.");
+            throw new BaseException(SEARCH_QUERY_MUST_NOT_BE_BLANK);
         }
     }
 }

--- a/src/main/java/koreatech/in/dto/admin/member/request/UpdateMemberRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/member/request/UpdateMemberRequest.java
@@ -10,40 +10,40 @@ import javax.validation.constraints.Size;
 
 @Getter @Setter
 public class UpdateMemberRequest {
-    @NotNull
-    @Size(max = 50)
+    @NotNull(message = "이름은 필수입니다.")
+    @Size(max = 50, message = "이름의 길이는 최대 50자입니다.")
     @ApiModelProperty(notes = "이름 \n" +
                               "- not null \n" +
                               "- 최대 50자", example = "김주원", required = true)
     private String name;
 
-    @Size(max = 10)
+    @Size(max = 10, message = "학번의 길이는 최대 10자입니다.")
     @ApiModelProperty(notes = "학번 \n" +
                               "- 최대 10자", example = "2019136037")
     private String student_number;
 
-    @NotNull
-    @Pattern(regexp = "^(Android|BackEnd|FrontEnd|Game|UI\\/UX)$")
+    @NotNull(message = "트랙은 필수입니다.")
+    @Pattern(regexp = "^(Android|BackEnd|FrontEnd|Game|UI\\/UX)$", message = "트랙의 형식이 올바르지 않습니다.")
     @ApiModelProperty(notes = "소속 트랙 \n" +
                               "- not null \n" +
                               "- Android, BackEnd, FrontEnd, Game, UI/UX 중 택 1 " +
                               "(정규식 `^(Android|BackEnd|FrontEnd|Game|UI\\/UX)$` 을 만족해야함)", example = "BackEnd", required = true)
     private String track;
 
-    @NotNull
-    @Pattern(regexp = "^(Mentor|Regular)$")
+    @NotNull(message = "직급은 필수입니다.")
+    @Pattern(regexp = "^(Mentor|Regular)$", message = "직급의 형식이 올바르지 않습니다.")
     @ApiModelProperty(notes = "직급 \n" +
                               "- not null \n" +
                               "- Mentor 또는 Regular 중 택 1 " +
                               "(정규식 `^(Mentor|Regular)$` 을 만족해야함)", example = "Regular", required = true)
     private String position;
 
-    @Size(max = 100)
+    @Size(max = 100, message = "이메일의 길이는 최대 100자입니다.")
     @ApiModelProperty(notes = "이메일 \n" +
                               "- 최대 100자", example = "damiano102777@naver.com")
     private String email;
 
-    @Size(max = 65535)
+    @Size(max = 65535, message = "이미지 링크의 길이는 최대 65535자입니다.")
     @ApiModelProperty(notes = "이미지 링크 \n" +
                               "- 최대 65535자", example = "https://example.com")
     private String image_url;

--- a/src/main/java/koreatech/in/exception/BaseException.java
+++ b/src/main/java/koreatech/in/exception/BaseException.java
@@ -13,15 +13,4 @@ public class BaseException extends ParentException {
         this.errorCode = exceptionInformation.getCode();
         this.httpStatus = exceptionInformation.getHttpStatus();
     }
-
-    /**
-     *
-     * @param message ExceptionInformation Enum에 저장된 message가 아닌, 직접 입력하여 적용할 message
-     * @param exceptionInformation ExceptionInformation Enum
-     */
-    public BaseException(String message, ExceptionInformation exceptionInformation) {
-        super(message);
-        this.errorCode = exceptionInformation.getCode();
-        this.httpStatus = exceptionInformation.getHttpStatus();
-    }
 }

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -59,7 +59,16 @@ public enum ExceptionInformation {
     // ======= BCSDLab 회원 =======
     MEMBER_NOT_FOUND("존재하지 않는 BCSDLab 회원입니다.", 202000, HttpStatus.NOT_FOUND),
     MEMBER_ALREADY_DELETED("이미 삭제되어 있는 BCSDLab 회원입니다.", 202001, HttpStatus.CONFLICT),
-    MEMBER_NOT_DELETED("삭제되어 있는 BCSDLab 회원이 아닙니다.", 202002, HttpStatus.CONFLICT);
+    MEMBER_NOT_DELETED("삭제되어 있는 BCSDLab 회원이 아닙니다.", 202002, HttpStatus.CONFLICT),
+
+
+    // ======= 422 (unprocessable entity) exception =======
+    SEARCH_QUERY_LENGTH_AT_LEAST_1("검색 내용의 최소 길이는 1입니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
+    SEARCH_QUERY_MUST_NOT_BE_BLANK("검색 내용은 공백 문자로만 이루어져 있으면 안됩니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
+    NICKNAME_SHOULD_NOT_BE_NULL("닉네임은 필수입니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
+    NICKNAME_LENGTH_AT_LEAST_1("닉네임의 최소 길이는 1입니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
+    NICKNAME_MUST_NOT_BE_BLANK("닉네임은 공백 문자로만 이루어져 있으면 안됩니다,", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
+    NICKNAME_MAXIMUM_LENGTH_IS_10("닉네임은 최대 10자입니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY);
 
     ExceptionInformation(String message, Integer code, HttpStatus httpStatus) {
         this.message = message;

--- a/src/main/java/koreatech/in/exception/RequestDataInvalidException.java
+++ b/src/main/java/koreatech/in/exception/RequestDataInvalidException.java
@@ -2,20 +2,13 @@ package koreatech.in.exception;
 
 import lombok.Getter;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static koreatech.in.exception.ExceptionInformation.REQUEST_DATA_INVALID;
 
 @Getter
 public class RequestDataInvalidException extends BaseException {
     private final List<String> violations;
-
-    public RequestDataInvalidException(String... violations) {
-        super(REQUEST_DATA_INVALID);
-        this.violations = Arrays.stream(violations).collect(Collectors.toList());
-    }
 
     public RequestDataInvalidException(List<String> violations) {
         super(REQUEST_DATA_INVALID);

--- a/src/main/java/koreatech/in/exception/RequestDataInvalidException.java
+++ b/src/main/java/koreatech/in/exception/RequestDataInvalidException.java
@@ -1,0 +1,24 @@
+package koreatech.in.exception;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static koreatech.in.exception.ExceptionInformation.REQUEST_DATA_INVALID;
+
+@Getter
+public class RequestDataInvalidException extends BaseException {
+    private final List<String> violations;
+
+    public RequestDataInvalidException(String... violations) {
+        super(REQUEST_DATA_INVALID);
+        this.violations = Arrays.stream(violations).collect(Collectors.toList());
+    }
+
+    public RequestDataInvalidException(List<String> violations) {
+        super(REQUEST_DATA_INVALID);
+        this.violations = violations;
+    }
+}

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -373,11 +373,17 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
 
     private void checkNicknameValid(String nickname) {
+        if (nickname == null) {
+            throw new BaseException(NICKNAME_SHOULD_NOT_BE_NULL);
+        }
+        if (nickname.length() == 0) {
+            throw new BaseException(NICKNAME_LENGTH_AT_LEAST_1);
+        }
         if (StringUtils.isBlank(nickname)) {
-            throw new RequestDataInvalidException("닉네임은 필수이며, 한글자 이상이어야하고 공백 문자로만 이루어져 있으면 안됩니다.");
+            throw new BaseException(NICKNAME_MUST_NOT_BE_BLANK);
         }
         if (nickname.length() > 10) {
-            throw new RequestDataInvalidException("닉네임은 최대 10글자 입니다.");
+            throw new BaseException(NICKNAME_MAXIMUM_LENGTH_IS_10);
         }
     }
 

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -374,10 +374,10 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     private void checkNicknameValid(String nickname) {
         if (StringUtils.isBlank(nickname)) {
-            throw new BaseException("nickname은 null이거나 길이가 0이거나 공백 문자로만 이루어져 있으면 안됩니다.", REQUEST_DATA_INVALID);
+            throw new RequestDataInvalidException("닉네임은 필수이며, 한글자 이상이어야하고 공백 문자로만 이루어져 있으면 안됩니다.");
         }
         if (nickname.length() > 10) {
-            throw new BaseException("nickname은 최대 10자입니다.", REQUEST_DATA_INVALID);
+            throw new RequestDataInvalidException("닉네임은 최대 10글자 입니다.");
         }
     }
 


### PR DESCRIPTION
# 422(Unprocessable Entity) Response에 대한 처리 방식 및 스키마 변경

## 스키마
### 기존 응답 스키마
- javax validation 어노테이션을 통해 검사되는 요청 데이터 제약조건 위반 사항들이 2개 이상일수 있었습니다.
- 그러나 기본 응답 스키마(`ExceptionResponse`)는 다음과 같았습니다.

```java
@Getter
@AllArgsConstructor
public class ExceptionResponse {
    @ApiModelProperty(notes = "에러 코드", required = true)
    private Integer code;
    @ApiModelProperty(notes = "에러 메시지", required = true)
    private String message;

    public static ExceptionResponse of(Integer code, String message) {
        return new ExceptionResponse(code, message);
    }
}
```

```json
{
  "code": 100000,
  "message": "string"
}
```

- 위반 사항이 2가지 이상 경우, message 프로퍼티는 List가 아니기 때문에 내용을 담을 수 없었습니다.

### 개선된 응답 스키마
- 따라서 422 응답은 `ExceptionResponse`를 상속하는 `RequestDataInvalidResponse`를 응답하도록 하였습니다.
  - `violations` 프로퍼티는 `List<String>` 타입으로, 여러개의 위반 내용들을 담을 수 있습니다.
    - 내용이 1개일때는 size 1의 List를 담습니다.

```java
@Getter
public class RequestDataInvalidResponse extends ExceptionResponse {
    private final List<String> violations;

    private RequestDataInvalidResponse(Integer code, String message, List<String> violations) {
        super(code, message);
        this.violations = violations;
    }

    public static RequestDataInvalidResponse of(Integer code, String message, List<String> violations) {
        return new RequestDataInvalidResponse(code, message, violations);
    }
}
```

```json
{
  "code": 100000,
  "message": "요청 데이터가 유효하지 않습니다.",
  "violations": [
    "이름은 필수입니다.",
    "직급의 형식이 올바르지 않습니다.",
    "학번의 길이는 최대 10자입니다."
  ]
}
```

## 처리 방식
### javax validation을 통한 검증의 경우
- javax validation 어노테이션을 통해 발견된 제약조건 위반 사항은 `BindingResult` 객체에 담기게 되고, `ValidParameters` 어노테이션에 의해 메시지가 추출하여 예외를 throw합니다.
- 이때, BaseException을 상속받는 `RequestDataInvalidException`을 throw하여, `List<String>` 타입의 `violations`를 넣어 여러개의 위반 사항을 넣을 수 있도록 하였습니다.

```java
@Getter
public class RequestDataInvalidException extends BaseException {
    private final List<String> violations;

    public RequestDataInvalidException(List<String> violations) {
        super(REQUEST_DATA_INVALID);
        this.violations = violations;
    }
}
```

- 그리고 해당 RequestDataInvalidException 객체를 `GlobalExceptionHandler`에서 받아서 ReuestDataInvalidResponse를 응답합니다.

```java
@ExceptionHandler(RequestDataInvalidException.class)
public @ResponseBody
ResponseEntity<RequestDataInvalidResponse> RequestDataInvalidException(RequestDataInvalidException e) {
    return new ResponseEntity<>(RequestDataInvalidResponse.of(e.getErrorCode(), e.getMessage(), e.getViolations()), e.getHttpStatus());
}
```

### javax validation 이후에 검증하는 경우
- javax validation만으로는 검증할 수 없는 데이터 제약조건도 존재합니다.
- 이 경우는 논리적으로 하나의 위반사항에 대해서만 throw합니다.
- BaseException에 ExceptionInformation Enum 객체를 넣어 throw하도록 합니다.
   - ExceptionInformation에 해당 내용 정의가 선행되어야 합니다.
      - error code는 100000, http status는 422로 고정
- 그리고 이것을 GlobalExceptionHandler의 BaseException.class 타입에 대해 Catch하는 곳에서 다음과 같이 처리하도록 합니다.
   - http status가 422일 경우 error code, message, http status는 422 응답에 맞게 고정시키고, `violations` 프로퍼티만 size 1의 List로 응답

```java
@ExceptionHandler(BaseException.class)
public @ResponseBody
ResponseEntity<ExceptionResponse> BaseException(BaseException e) {
    HttpStatus httpStatus = e.getHttpStatus();
    if (httpStatus.equals(UNPROCESSABLE_ENTITY)) {
        return new ResponseEntity<>(RequestDataInvalidResponse.of(
                REQUEST_DATA_INVALID.getCode(),
                REQUEST_DATA_INVALID.getMessage(),
                Collections.singletonList(e.getMessage())
        ),
                REQUEST_DATA_INVALID.getHttpStatus()
        );
    }

    return new ResponseEntity<>(ExceptionResponse.of(e.getErrorCode(), e.getMessage()), e.getHttpStatus());
}
```