### PR TITLE
Refactor: 로그아웃 방식 수정

### DIFF
--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -120,8 +120,10 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public void logout() {
-        jwtValidator.validate(); // access token 인증이 잘 되는지 확인
+        User user = jwtValidator.validate();
+        deleteAccessTokenFromRedis(user.getId());
     }
 
     @Transactional

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -101,7 +101,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     @Override
     public void logoutForAdmin() {
         User user = jwtValidator.validate();
-        stringRedisUtilStr.deleteData(redisLoginTokenKeyPrefix + user.getId().toString());
+        deleteAccessTokenFromRedis(user.getId());
     }
 
 
@@ -340,5 +340,9 @@ public class AdminUserServiceImpl implements AdminUserService {
         map.put("totalPage", totalPage);
 
         return map;
+    }
+
+    private void deleteAccessTokenFromRedis(Integer userId) {
+        stringRedisUtilStr.deleteData(redisLoginTokenKeyPrefix + userId.toString());
     }
 }


### PR DESCRIPTION
- 일반 로그아웃 API에서, 로그아웃 이후에 기존 토큰을 무효화시키기위해, redis에서 access token을 삭제하는 로직 추가
- 어드민 로그아웃 API에서, redis에서 access token을 삭제하는 로직을 메소드로 분리