### PR TITLE
Task: `Account` -> `Email` 로 대체

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -72,15 +72,16 @@ public class UserController {
 
     @AuthExcept
     @ParamValid
-    @ApiOperation(value = "(required: account, password), (optional: name, nickname, gender, identity, is_graduated, major, student_number, phone_number)")
+    @ApiOperation(value = "(required: email, password), (optional: name, nickname, gender, identity, is_graduated, major, student_number, phone_number)")
     @RequestMapping(value = "/user/student/register", method = RequestMethod.POST)
     public @ResponseBody
     ResponseEntity studentRegister(
             @ApiParam(required = true) @RequestBody @Validated StudentRegisterRequest request,
             BindingResult bindingResult,
             HttpServletRequest httpServletRequest) throws Exception {
-        // TODO: 23.02.11. 박한수 Controller API Response 추가시  EMAIL_DUPLICATED 관한 내용도 추가하기.
-        // TODO: velocity template 에 인증 url에 들어갈 host를 넣기 위해 reigster에 url 데이터를 넘겼는데 추후 이 방법 없애고 plugin을 붙이는 방법으로 해결해보기
+        //TODO: 23.02.11. 박한수 Controller API Response 추가시  EMAIL_DUPLICATED 관한 내용도 추가하기.
+
+        //TODO: velocity template 에 인증 url에 들어갈 host를 넣기 위해 reigster에 url 데이터를 넘겼는데 추후 이 방법 없애고 plugin을 붙이는 방법으로 해결해보기
         // https://developer.atlassian.com/server/confluence/confluence-objects-accessible-from-velocity/
 
         StudentRegisterRequest clear = new StudentRegisterRequest();
@@ -162,6 +163,7 @@ public class UserController {
     @RequestMapping(value = "/user/find/password", method = RequestMethod.POST)
     public @ResponseBody
     ResponseEntity<EmptyResponse> changePasswordConfig(@RequestBody @Valid FindPasswordRequest request, BindingResult bindingResult, HttpServletRequest servletRequest) {
+    // TODO: 23.02.12. 박한수 현재: 익명사용자가 특정 회원의 비밀번호 변경 요청을 시도할 수 있음 -> 개선안: jwt 토큰에 있는 사용자의 이메일로 비밀변경 요청을 시도하게 해야 함.
 
         // TODO: velocity template 에 인증 url에 들어갈 host를 넣기 위해 reigster에 url 데이터를 넘겼는데 추후 이 방법 없애고 plugin을 붙이는 방법으로 해결해보기
         // https://developer.atlassian.com/server/confluence/confluence-objects-accessible-from-velocity/

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -1,7 +1,18 @@
 package koreatech.in.controller.admin;
 
-import io.swagger.annotations.*;
-import koreatech.in.annotation.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import java.util.Map;
+import javax.validation.Valid;
+import koreatech.in.annotation.ApiOff;
+import koreatech.in.annotation.Auth;
+import koreatech.in.annotation.AuthExcept;
+import koreatech.in.annotation.ParamValid;
+import koreatech.in.annotation.ValidationGroups;
 import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.domain.User.User;
@@ -10,6 +21,7 @@ import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
 import koreatech.in.dto.admin.user.request.LoginRequest;
 import koreatech.in.dto.admin.user.response.LoginResponse;
+import koreatech.in.dto.normal.user.request.UpdateUserRequest;
 import koreatech.in.service.admin.AdminUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -17,11 +29,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.validation.Valid;
-import java.util.Map;
 
 @Api(tags = "(Admin) User", description = "회원")
 @Auth(role = Auth.Role.ADMIN, authority = Auth.Authority.USER)
@@ -121,7 +136,7 @@ public class AdminUserController {
     @RequestMapping(value = "/admin/student/users", method = RequestMethod.POST)
     public @ResponseBody
     ResponseEntity createUser(
-            @ApiParam(value = "(required: portal_account, password), " +
+            @ApiParam(value = "(required: email, password), " +
                     "(optional: name, nickname, student_number, major, is_graduated, phone_number, gender, identity, is_authed)", required = true)
             @RequestBody @Validated(ValidationGroups.CreateAdmin.class) Student student,
             BindingResult bindingResult) throws Exception {

--- a/src/main/java/koreatech/in/domain/User/User.java
+++ b/src/main/java/koreatech/in/domain/User/User.java
@@ -1,6 +1,5 @@
 package koreatech.in.domain.User;
 
-import static koreatech.in.exception.ExceptionInformation.IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_ACCOUNT_EXIST;
 import static koreatech.in.exception.ExceptionInformation.IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_EMAIL_EXIST;
 import static koreatech.in.exception.ExceptionInformation.USER_HAS_NOT_WITHDRAWN;
 import static koreatech.in.exception.ExceptionInformation.USER_HAS_WITHDRAWN;
@@ -20,13 +19,12 @@ import lombok.Setter;
 @NoArgsConstructor
 public class User {
     protected Integer id;
-    protected String account;
+    protected String email;
     protected String password;
     protected String nickname;
     protected String name;
     protected String phone_number;
     protected UserType user_type;
-    protected String email;
     protected Integer gender;
     protected Boolean is_authed;
     protected Date last_logged_at;
@@ -40,20 +38,20 @@ public class User {
     protected Date created_at;
     protected Date updated_at;
 
-    protected User(String account, String password, String nickname, String name, String phoneNumber, String email, Integer gender, UserType userType) {
-        this.account = account;
+    protected User(String email, String password, String nickname, String name, String phoneNumber, Integer gender, UserType userType) {
+        this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.name = name;
         this.phone_number = phoneNumber;
-        this.email = email;
         this.gender = gender;
         this.user_type = userType;
+        this.is_authed = false;
     }
 
     public void update(User user) {
-        if (user.account != null) {
-            this.account = user.account;
+        if (user.email != null) {
+            this.email = user.email;
         }
         if (user.password != null) {
             this.password = user.password;
@@ -69,9 +67,6 @@ public class User {
         }
         if(user.phone_number != null) {
             this.phone_number = user.phone_number;
-        }
-        if(user.email != null) {
-            this.email = user.email;
         }
         if (user.is_authed != null) {
             this.is_authed = user.is_authed;
@@ -152,7 +147,7 @@ public class User {
 
     public void generateDataForFindPassword() {
         this.reset_expired_at = DateUtil.addHoursToJavaUtilDate(new Date(), 1);
-        this.reset_token = SHA256Util.getEncrypt(this.account, this.reset_expired_at.toString());
+        this.reset_token = SHA256Util.getEncrypt(this.email, this.reset_expired_at.toString());
     }
 
     public void changeToNewPassword(String password) {
@@ -166,12 +161,9 @@ public class User {
         }
     }
 
-    public void checkPossibilityOfUndeletion(User undeletedAndSameAccountUser, User undeletedAndSameEmailUser) {
+    public void checkPossibilityOfUndeletion(User undeletedAndSameEmailUser) {
         if (!isWithdrawn()) {
             throw new BaseException(USER_HAS_NOT_WITHDRAWN);
-        }
-        if (undeletedAndSameAccountUser != null) {
-            throw new BaseException(IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_ACCOUNT_EXIST);
         }
         if (undeletedAndSameEmailUser != null) {
             throw new BaseException(IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_EMAIL_EXIST);

--- a/src/main/java/koreatech/in/domain/User/Users.java
+++ b/src/main/java/koreatech/in/domain/User/Users.java
@@ -1,0 +1,4 @@
+package koreatech.in.domain.User;
+
+public class Users {
+}

--- a/src/main/java/koreatech/in/domain/User/student/Student.java
+++ b/src/main/java/koreatech/in/domain/User/student/Student.java
@@ -57,8 +57,8 @@ public class Student extends User {
     }
 
     @Builder
-    public Student(String account, String password, String email, String name, String nickname, String anonymousNickname, Integer gender, Integer identity, Boolean isGraduated, String major, String studentNumber, String phoneNumber){
-        super(account, password, nickname, name, phoneNumber, email, gender, UserType.STUDENT);
+    public Student(String email, String password, String name, String nickname, String anonymousNickname, Integer gender, Integer identity, Boolean isGraduated, String major, String studentNumber, String phoneNumber){
+        super(email, password, nickname, name, phoneNumber, gender, UserType.STUDENT);
         this.identity = identity;
         this.is_graduated = isGraduated;
         this.major = major;

--- a/src/main/java/koreatech/in/dto/admin/user/request/LoginRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/user/request/LoginRequest.java
@@ -2,18 +2,23 @@ package koreatech.in.dto.admin.user.request;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-
 @Getter @Setter @ApiModel("AdminLoginRequest")
 public class LoginRequest {
-    @NotNull(message = "아이디는 필수입니다.")
-    @Pattern(regexp = "^[a-z_0-9]{1,12}$", message = "아이디 형식이 올바르지 않습니다.")
-    @ApiModelProperty(notes = "아이디", required = true)
-    private String portal_account;
+    // TODO 23.02.12. Admin의 이메일을 이용가능한 동아리 내 메일로 변경하기.
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotNull(message = "이메일은 필수입니다.")
+    @ApiModelProperty(notes = "이메일 주소 \n"
+            + "- not null \n"
+            + "- 이메일 형식이어야 함"
+            , required = true
+            , example = "abcd@gmail.com"
+    )
+    private String email;
 
     @NotNull(message = "비밀번호는 필수입니다.")
     @ApiModelProperty(notes = "비밀번호", required = true)

--- a/src/main/java/koreatech/in/dto/normal/user/request/FindPasswordRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/request/FindPasswordRequest.java
@@ -1,6 +1,7 @@
 package koreatech.in.dto.normal.user.request;
 
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.Email;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,8 +9,14 @@ import javax.validation.constraints.NotNull;
 
 @Getter @Setter
 public class FindPasswordRequest {
-    @NotNull(message = "account는 필수입니다.")
-    @ApiModelProperty(notes = "아이디 \n" +
-                              "- not null", example = "acsdefg1234", required = true)
-    private String account;
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotNull(message = "이메일은 필수입니다.")
+    @ApiModelProperty(notes = "이메일 주소 \n"
+            + "- not null \n"
+            + "- 이메일 형식이어야 함"
+            , required = true
+            , example = "abcd@gmail.com"
+    )
+    private String email;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/request/LoginRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/request/LoginRequest.java
@@ -1,18 +1,22 @@
 package koreatech.in.dto.normal.user.request;
 
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-
 @Getter @Setter
 public class LoginRequest {
-    @NotNull(message = "account는 필수입니다.")
-    @Pattern(regexp = "^[a-z_0-9]{1,12}$", message = "account의 형식이 올바르지 않습니다.")
-    @ApiModelProperty(notes = "아이디", example = "damiano1027", required = true)
-    private String account;
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotNull(message = "이메일은 필수입니다.")
+    @ApiModelProperty(notes = "이메일 주소 \n"
+            + "- not null \n"
+            + "- 이메일 형식이어야 함"
+            , required = true
+            , example = "abcd@gmail.com"
+    )
+    private String email;
 
     @NotNull(message = "password는 필수입니다.")
     @ApiModelProperty(notes = "비밀번호", required = true)

--- a/src/main/java/koreatech/in/dto/normal/user/request/StudentRegisterRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/request/StudentRegisterRequest.java
@@ -4,34 +4,20 @@ package koreatech.in.dto.normal.user.request;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import koreatech.in.domain.User.student.Student;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-public class StudentRegisterRequest {
-    @NotNull(message = "아이디는 비워둘 수 없습니다.")
-    @Pattern(regexp = "^[a-z_0-9]{1,12}$", message = "아이디 형식이 올바르지 않습니다.")
-    @ApiModelProperty(notes = "아이디", example = "jjw266")
-    private String account;
-
-    @NotNull(message = "비밀번호는 비워둘 수 없습니다.")
-    @ApiModelProperty(notes = "비밀번호", example = "a0240120305812krlakdsflsa;1235")
-    private String password;
-
-    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
-    @ApiModelProperty(notes = "이름", example = "정보혁")
-    private String name;
+public class StudentRegisterRequest extends UserRegisterRequest{
 
     @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
     @ApiModelProperty(notes = "닉네임", example = "bbo")
@@ -60,9 +46,9 @@ public class StudentRegisterRequest {
         }
 
         return Student.builder()
-                .account(account)
-                .password(password)
-                .name(name)
+                .email(getEmail())
+                .password(getPassword())
+                .name(getName())
                 .nickname(nickname)
                 .gender(gender)
                 .identity(identity)

--- a/src/main/java/koreatech/in/dto/normal/user/request/UserRegisterRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/request/UserRegisterRequest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
 import lombok.Getter;
@@ -18,24 +17,6 @@ import lombok.Setter;
 
 public class UserRegisterRequest {
 
-    @NotNull(message = "아이디는 비워둘 수 없습니다.")
-    @Pattern(regexp = "^[a-z_0-9]{1,12}$", message = "아이디 형식이 올바르지 않습니다.")
-    @ApiModelProperty(notes = "아이디 \n"
-            + "- not null \n"
-            + "아이디 형식이어야 함"
-            , required = true
-            , example = "jjw266"
-    )
-    private String account;
-
-    @NotNull(message = "비밀번호는 비워둘 수 없습니다.")
-    @ApiModelProperty(notes = "비밀번호 \n"
-            + "- not null"
-            , required = true
-            , example = "a0240120305812krlakdsflsa;1235"
-    )
-    private String password;
-
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     @NotNull(message = "이메일은 필수입니다.")
     @ApiModelProperty(notes = "이메일 주소 \n"
@@ -45,6 +26,14 @@ public class UserRegisterRequest {
             , example = "abcd@gmail.com"
     )
     private String email;
+
+    @NotNull(message = "비밀번호는 비워둘 수 없습니다.")
+    @ApiModelProperty(notes = "비밀번호 \n"
+            + "- not null"
+            , required = true
+            , example = "a0240120305812krlakdsflsa;1235"
+    )
+    private String password;
 
     @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
     @ApiModelProperty(notes = "이름 \n"

--- a/src/main/java/koreatech/in/dto/normal/user/response/UserResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/user/response/UserResponse.java
@@ -13,11 +13,10 @@ import lombok.Setter;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class UserResponse {
     private Integer id;
-    private String account;
+    private String email;
     private String nickname;
     private String name;
     private String phoneNumber;
-    private String email;
     private Integer gender;
     private Boolean isAuth;
     private UserType userType;
@@ -25,11 +24,10 @@ public class UserResponse {
 
     public UserResponse(User user) {
         this.id = user.getId();
-        this.account = user.getAccount();
+        this.email = user.getEmail();
         this.nickname = user.getNickname();
         this.name = user.getName();
         this.phoneNumber = user.getPhone_number();
-        this.email = user.getEmail();
         this.gender = user.getGender();
         this.isAuth = user.getIs_authed();
         this.userType = user.getUser_type();

--- a/src/main/java/koreatech/in/dto/normal/user/response/UsersResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/user/response/UsersResponse.java
@@ -19,8 +19,8 @@ public class UsersResponse {
         @ApiModelProperty(notes = "고유 id", example = "1", required = true)
         private Integer id;
 
-        @ApiModelProperty(notes = "포탈 아이디", example = "asdf1234", required = true)
-        private String portal_account;
+        @ApiModelProperty(notes = "이메일", example = "asdf1234@koreatech.ac.kr", required = true)
+        private String email;
 
         @ApiModelProperty(notes = "닉네임", example = "1")
         private String nickname;

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -56,7 +56,6 @@ public interface OwnerConverter {
 
 
     @Mappings({
-            @Mapping(source = "account", target = "account"),
             @Mapping(source = "password", target = "password"),
             @Mapping(source = "email", target = "email"),
             @Mapping(source = "name", target = "name")

--- a/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
+++ b/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AdminUserMapper {
     User getUserById(@Param("id") Integer id);
-    User getUndeletedUserByAccount(@Param("account") String account);
     User getUndeletedUserByEmail(@Param("email") String email);
     void deleteUserLogicallyById(@Param("id") Integer id);
     void undeleteUserLogicallyById(@Param("id") Integer id);

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -1,19 +1,20 @@
 package koreatech.in.repository.user;
 
-import koreatech.in.domain.Authority;
-import koreatech.in.domain.User.EmailAddress;
-import koreatech.in.domain.User.UserType;
-import koreatech.in.domain.User.User;
-import org.apache.ibatis.annotations.*;
-import org.springframework.stereotype.Repository;
-
 import java.sql.SQLException;
 import java.util.Date;
+import koreatech.in.domain.Authority;
+import koreatech.in.domain.User.EmailAddress;
+import koreatech.in.domain.User.User;
+import koreatech.in.domain.User.UserType;
+import koreatech.in.domain.User.Users;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserMapper {
     User getAuthedUserById(@Param("id") Integer id);
-    User getAuthedUserByAccount(@Param("account") String account);
+    User getAuthedUserByEmail(@Param("email") String email);
     void updateLastLoggedAt(@Param("id") Integer id, @Param("currentDate") Date currentDate);
     void deleteUserLogicallyById(@Param("id") Integer id);
     void undeleteUserLogicallyById(@Param("id") Integer id);
@@ -24,7 +25,7 @@ public interface UserMapper {
     User getAuthedUserByResetToken(@Param("resetToken") String resetToken);
 
 
-    Integer isAccountAlreadyUsed(String account);
+//    Integer isAccountAlreadyUsed(String account);
     Integer isNicknameAlreadyUsed(String nickname);
     void updateUserIsAuthed(@Param("id")Integer id, @Param("isAuth")Boolean isAuth);
     void updateResetTokenAndResetTokenExpiredTime(@Param("id") Integer id, @Param("resetToken") String resetToken, @Param("resetTokenExpiredTime") Date resetTokenExpiredTime);
@@ -35,10 +36,11 @@ public interface UserMapper {
     Authority getAuthorityByUserIdForAdmin(@Param("id") int id);
     void insertUser(User user) throws SQLException;
     User getUserById(@Param("id") int id);
+
     UserType getUserTypeById(@Param("id") int id);
     String getUserEmail(@Param("id") int id);
     Integer getTotalCount();
-    User getUserByAccount(String account);
+    User getUserByEmail(String email);
 
     // TODO: JOIN으로 처리할 수 있는지 알아보기.
 //    @Select("SELECT * FROM koin.users u INNER JOIN koin.admins a ON u.id = a.user_id WHERE u.id = #{id}")

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -1,13 +1,14 @@
 package koreatech.in.service.admin;
 
+import java.util.Map;
 import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.Criteria;
 import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.student.Student;
 import koreatech.in.dto.admin.user.request.LoginRequest;
 import koreatech.in.dto.admin.user.response.LoginResponse;
-
-import java.util.Map;
+import koreatech.in.dto.normal.user.request.UpdateUserRequest;
+import koreatech.in.dto.normal.user.response.StudentResponse;
 
 public interface AdminUserService {
     LoginResponse loginForAdmin(LoginRequest request) throws Exception;

--- a/src/main/resources/db/migration/V69.000__alter_drop_user_account.sql
+++ b/src/main/resources/db/migration/V69.000__alter_drop_user_account.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `koin`.`users`
+    DROP COLUMN `account`

--- a/src/main/resources/mapper/admin/AdminUserMapper.xml
+++ b/src/main/resources/mapper/admin/AdminUserMapper.xml
@@ -5,13 +5,12 @@
     <select id="getUserById" parameterType="integer" resultMap="UserDiscriminator">
         SELECT
             `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
+            `t1`.`email` AS `users.email`,
             `t1`.`password` AS `users.password`,
             `t1`.`nickname` AS `users.nickname`,
             `t1`.`name` AS `users.name`,
             `t1`.`phone_number` AS `users.phone_number`,
             `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
             `t1`.`gender` AS `users.gender`,
             `t1`.`is_authed` AS `users.is_authed`,
             `t1`.`last_logged_at` AS `users.last_logged_at`,
@@ -72,87 +71,86 @@
                 AND `t4`.`is_deleted` = 0
     </select>
 
-    <select id="getUndeletedUserByAccount" parameterType="string" resultMap="UserDiscriminator">
-        SELECT
-            `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
-            `t1`.`password` AS `users.password`,
-            `t1`.`nickname` AS `users.nickname`,
-            `t1`.`name` AS `users.name`,
-            `t1`.`phone_number` AS `users.phone_number`,
-            `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
-            `t1`.`gender` AS `users.gender`,
-            `t1`.`is_authed` AS `users.is_authed`,
-            `t1`.`last_logged_at` AS `users.last_logged_at`,
-            `t1`.`profile_image_url` AS `users.profile_image_url`,
-            `t1`.`auth_token` AS `users.auth_token`,
-            `t1`.`auth_expired_at` AS `users.auth_expired_at`,
-            `t1`.`reset_token` AS `users.reset_token`,
-            `t1`.`reset_expired_at` AS `users.reset_expired_at`,
-            `t1`.`is_deleted` AS `users.is_deleted`,
-            `t1`.`created_at` AS `users.created_at`,
-            `t1`.`updated_at` AS `users.updated_at`,
+<!--    <select id="getUndeletedUserByAccount" parameterType="string" resultMap="UserDiscriminator">-->
+<!--        SELECT-->
+<!--            `t1`.`id` AS `users.id`,-->
+<!--            `t1`.`account` AS `users.account`,-->
+<!--            `t1`.`password` AS `users.password`,-->
+<!--            `t1`.`nickname` AS `users.nickname`,-->
+<!--            `t1`.`name` AS `users.name`,-->
+<!--            `t1`.`phone_number` AS `users.phone_number`,-->
+<!--            `t1`.`user_type` AS `users.user_type`,-->
+<!--            `t1`.`email` AS `users.email`,-->
+<!--            `t1`.`gender` AS `users.gender`,-->
+<!--            `t1`.`is_authed` AS `users.is_authed`,-->
+<!--            `t1`.`last_logged_at` AS `users.last_logged_at`,-->
+<!--            `t1`.`profile_image_url` AS `users.profile_image_url`,-->
+<!--            `t1`.`auth_token` AS `users.auth_token`,-->
+<!--            `t1`.`auth_expired_at` AS `users.auth_expired_at`,-->
+<!--            `t1`.`reset_token` AS `users.reset_token`,-->
+<!--            `t1`.`reset_expired_at` AS `users.reset_expired_at`,-->
+<!--            `t1`.`is_deleted` AS `users.is_deleted`,-->
+<!--            `t1`.`created_at` AS `users.created_at`,-->
+<!--            `t1`.`updated_at` AS `users.updated_at`,-->
 
-            `t2`.`anonymous_nickname` AS `students.anonymous_nickname`,
-            `t2`.`student_number` AS `students.student_number`,
-            `t2`.`major` AS `students.major`,
-            `t2`.`identity` AS `students.identity`,
-            `t2`.`is_graduated` AS `students.is_graduated`,
+<!--            `t2`.`anonymous_nickname` AS `students.anonymous_nickname`,-->
+<!--            `t2`.`student_number` AS `students.student_number`,-->
+<!--            `t2`.`major` AS `students.major`,-->
+<!--            `t2`.`identity` AS `students.identity`,-->
+<!--            `t2`.`is_graduated` AS `students.is_graduated`,-->
 
-            `t3`.`company_registration_number` AS `owners.company_registration_number`,
-            `t3`.`company_registration_certificate_image_url` AS `owners.company_registration_certificate_image_url`,
-            `t3`.`grant_shop` AS `owners.grant_shop`,
-            `t3`.`grant_event` AS `owners.grant_event`,
+<!--            `t3`.`company_registration_number` AS `owners.company_registration_number`,-->
+<!--            `t3`.`company_registration_certificate_image_url` AS `owners.company_registration_certificate_image_url`,-->
+<!--            `t3`.`grant_shop` AS `owners.grant_shop`,-->
+<!--            `t3`.`grant_event` AS `owners.grant_event`,-->
 
-            `t4`.`id` AS `admins.id`,
-            `t4`.`user_id` AS `admins.user_id`,
-            `t4`.`grant_user` AS `admins.grant_user`,
-            `t4`.`grant_callvan` AS `admins.grant_callvan`,
-            `t4`.`grant_land` AS `admins.grant_land`,
-            `t4`.`grant_community` AS `admins.grant_community`,
-            `t4`.`grant_shop` AS `admins.grant_shop`,
-            `t4`.`grant_version` AS `admins.grant_version`,
-            `t4`.`grant_market` AS `admins.grant_market`,
-            `t4`.`grant_circle` AS `admins.grant_circle`,
-            `t4`.`grant_lost` AS `admins.grant_lost`,
-            `t4`.`grant_survey` AS `admins.grant_survey`,
-            `t4`.`grant_bcsdlab` AS `admins.grant_bcsdlab`,
-            `t4`.`grant_event` AS `admins.grant_event`,
-            `t4`.`is_deleted` AS `admins.is_deleted`,
-            `t4`.`created_at` AS `admins.created_at`,
-            `t4`.`updated_at` AS `admins.updated_at`
+<!--            `t4`.`id` AS `admins.id`,-->
+<!--            `t4`.`user_id` AS `admins.user_id`,-->
+<!--            `t4`.`grant_user` AS `admins.grant_user`,-->
+<!--            `t4`.`grant_callvan` AS `admins.grant_callvan`,-->
+<!--            `t4`.`grant_land` AS `admins.grant_land`,-->
+<!--            `t4`.`grant_community` AS `admins.grant_community`,-->
+<!--            `t4`.`grant_shop` AS `admins.grant_shop`,-->
+<!--            `t4`.`grant_version` AS `admins.grant_version`,-->
+<!--            `t4`.`grant_market` AS `admins.grant_market`,-->
+<!--            `t4`.`grant_circle` AS `admins.grant_circle`,-->
+<!--            `t4`.`grant_lost` AS `admins.grant_lost`,-->
+<!--            `t4`.`grant_survey` AS `admins.grant_survey`,-->
+<!--            `t4`.`grant_bcsdlab` AS `admins.grant_bcsdlab`,-->
+<!--            `t4`.`grant_event` AS `admins.grant_event`,-->
+<!--            `t4`.`is_deleted` AS `admins.is_deleted`,-->
+<!--            `t4`.`created_at` AS `admins.created_at`,-->
+<!--            `t4`.`updated_at` AS `admins.updated_at`-->
 
-        FROM (
-            SELECT *
-            FROM `koin`.`users`
-            WHERE
-                `account` = #{account}
-                AND `is_deleted` = 0
-        ) `t1`
+<!--        FROM (-->
+<!--            SELECT *-->
+<!--            FROM `koin`.`users`-->
+<!--            WHERE-->
+<!--                `account` = #{account}-->
+<!--                AND `is_deleted` = 0-->
+<!--        ) `t1`-->
 
-            LEFT JOIN `koin`.`students` `t2`
-            ON `t1`.`id` = `t2`.`user_id`
+<!--            LEFT JOIN `koin`.`students` `t2`-->
+<!--            ON `t1`.`id` = `t2`.`user_id`-->
 
-            LEFT JOIN `koin`.`owners` `t3`
-            ON `t1`.`id` = `t3`.`user_id`
+<!--            LEFT JOIN `koin`.`owners` `t3`-->
+<!--            ON `t1`.`id` = `t3`.`user_id`-->
 
-            LEFT JOIN `koin`.`admins` `t4`
-            ON
-                `t1`.`id` = `t4`.`user_id`
-                AND `t4`.`is_deleted` = 0
-    </select>
+<!--            LEFT JOIN `koin`.`admins` `t4`-->
+<!--            ON-->
+<!--                `t1`.`id` = `t4`.`user_id`-->
+<!--                AND `t4`.`is_deleted` = 0-->
+<!--    </select>-->
 
     <select id="getUndeletedUserByEmail" parameterType="string" resultMap="UserDiscriminator">
         SELECT
             `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
+            `t1`.`email` AS `users.email`,
             `t1`.`password` AS `users.password`,
             `t1`.`nickname` AS `users.nickname`,
             `t1`.`name` AS `users.name`,
             `t1`.`phone_number` AS `users.phone_number`,
             `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
             `t1`.`gender` AS `users.gender`,
             `t1`.`is_authed` AS `users.is_authed`,
             `t1`.`last_logged_at` AS `users.last_logged_at`,
@@ -235,13 +233,12 @@
 
     <resultMap id="UserResultMap" type="koreatech.in.domain.User.User">
         <id property="id" column="users.id"/>
-        <result property="account" column="users.account"/>
+        <result property="email" column="users.email"/>
         <result property="password" column="users.password"/>
         <result property="nickname" column="users.nickname"/>
         <result property="name" column="users.name"/>
         <result property="phone_number" column="users.phone_number"/>
         <result property="user_type" column="users.user_type"/>
-        <result property="email" column="users.email"/>
         <result property="gender" column="users.gender"/>
         <result property="is_authed" column="users.is_authed"/>
         <result property="last_logged_at" column="users.last_logged_at"/>

--- a/src/main/resources/mapper/normal/StudentMapper.xml
+++ b/src/main/resources/mapper/normal/StudentMapper.xml
@@ -20,22 +20,22 @@
         )
         VALUES (
             #{id},
-            #{anonymousNickname},
-            #{studentNumber},
+            #{anonymous_nickname},
+            #{student_number},
             #{major},
             #{identity},
-            #{isGraduated}
+            #{is_graduated}
         );
     </insert>
 
     <update id="updateStudent">
         update koin.students
         set
-            anonymous_nickname=#{anonymousNickname},
-            student_number=#{studentNumber},
+            anonymous_nickname=#{anonymous_nickname},
+            student_number=#{student_number},
             major=#{major},
             identity=#{identity},
-            is_graduated=#{isGraduated}
+            is_graduated=#{is_graduated}
         where
             user_id=#{id}
     </update>

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -4,13 +4,12 @@
     <select id="getAuthedUserById" resultMap="UserDiscriminator">
         SELECT
             `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
+            `t1`.`email` AS `users.email`,
             `t1`.`password` AS `users.password`,
             `t1`.`nickname` AS `users.nickname`,
             `t1`.`name` AS `users.name`,
             `t1`.`phone_number` AS `users.phone_number`,
             `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
             `t1`.`gender` AS `users.gender`,
             `t1`.`is_authed` AS `users.is_authed`,
             `t1`.`last_logged_at` AS `users.last_logged_at`,
@@ -72,16 +71,15 @@
                 AND `t4`.`is_deleted` = 0
     </select>
 
-    <select id="getAuthedUserByAccount" resultMap="UserDiscriminator">
+    <select id="getAuthedUserByEmail" resultMap="UserDiscriminator">
         SELECT
             `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
+            `t1`.`email` AS `users.email`,
             `t1`.`password` AS `users.password`,
             `t1`.`nickname` AS `users.nickname`,
             `t1`.`name` AS `users.name`,
             `t1`.`phone_number` AS `users.phone_number`,
             `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
             `t1`.`gender` AS `users.gender`,
             `t1`.`is_authed` AS `users.is_authed`,
             `t1`.`last_logged_at` AS `users.last_logged_at`,
@@ -126,7 +124,7 @@
             SELECT *
             FROM `koin`.`users`
             WHERE
-                `account` = #{account}
+                `email` = #{email}
                 AND `is_authed` = 1
                 AND `is_deleted` = 0
         ) `t1`
@@ -143,6 +141,10 @@
                 AND `t4`.`is_deleted` = 0
     </select>
 
+    <resultMap id="UsersResultMap" type="koreatech.in.domain.User.Users">
+        <collection property="users" resultMap="UserResultMap"/>
+    </resultMap>
+
     <resultMap id="UserDiscriminator" type="koreatech.in.domain.User.User" >
         <discriminator javaType="String" column="users.user_type">
             <case value="STUDENT" resultMap="StudentResultMap"/>
@@ -152,13 +154,12 @@
 
     <resultMap id="UserResultMap" type="koreatech.in.domain.User.User">
         <id property="id" column="users.id"/>
-        <result property="account" column="users.account"/>
+        <result property="email" column="users.email"/>
         <result property="password" column="users.password"/>
         <result property="nickname" column="users.nickname"/>
         <result property="name" column="users.name"/>
         <result property="phone_number" column="users.phone_number"/>
         <result property="user_type" column="users.user_type"/>
-        <result property="email" column="users.email"/>
         <result property="gender" column="users.gender"/>
         <result property="is_authed" column="users.is_authed"/>
         <result property="last_logged_at" column="users.last_logged_at"/>
@@ -228,13 +229,12 @@
     <select id="getUserByNickname" parameterType="string" resultMap="UserDiscriminator">
         SELECT
             `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
+            `t1`.`email` AS `users.email`,
             `t1`.`password` AS `users.password`,
             `t1`.`nickname` AS `users.nickname`,
             `t1`.`name` AS `users.name`,
             `t1`.`phone_number` AS `users.phone_number`,
             `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
             `t1`.`gender` AS `users.gender`,
             `t1`.`is_authed` AS `users.is_authed`,
             `t1`.`last_logged_at` AS `users.last_logged_at`,
@@ -298,13 +298,12 @@
     <update id="updateUser">
         UPDATE `koin`.`users`
         SET
-            `account` = #{user.account},
+            `email` = #{user.email},
             `password` = #{user.password},
             `nickname` = #{user.nickname},
             `name` = #{user.name},
             `phone_number` = #{user.phone_number},
             `user_type` = #{user.user_type},
-            `email` = #{user.email},
             `gender` = #{user.gender},
             `is_authed` = #{user.is_authed},
             `last_logged_at` = #{user.last_logged_at},
@@ -319,13 +318,12 @@
     <select id="getUserByAuthToken" parameterType="string" resultMap="UserDiscriminator">
         SELECT
             `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
+            `t1`.`email` AS `users.email`,
             `t1`.`password` AS `users.password`,
             `t1`.`nickname` AS `users.nickname`,
             `t1`.`name` AS `users.name`,
             `t1`.`phone_number` AS `users.phone_number`,
             `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
             `t1`.`gender` AS `users.gender`,
             `t1`.`is_authed` AS `users.is_authed`,
             `t1`.`last_logged_at` AS `users.last_logged_at`,
@@ -389,13 +387,12 @@
     <select id="getAuthedUserByResetToken" parameterType="string" resultMap="UserDiscriminator">
         SELECT
             `t1`.`id` AS `users.id`,
-            `t1`.`account` AS `users.account`,
+            `t1`.`email` AS `users.email`,
             `t1`.`password` AS `users.password`,
             `t1`.`nickname` AS `users.nickname`,
             `t1`.`name` AS `users.name`,
             `t1`.`phone_number` AS `users.phone_number`,
             `t1`.`user_type` AS `users.user_type`,
-            `t1`.`email` AS `users.email`,
             `t1`.`gender` AS `users.gender`,
             `t1`.`is_authed` AS `users.is_authed`,
             `t1`.`last_logged_at` AS `users.last_logged_at`,
@@ -480,6 +477,13 @@
         limit 1;
     </select>
 
+<!--    <select id="isAccountAlreadyUsed" resultType="Integer">-->
+<!--        select count(*)-->
+<!--        from koin.users-->
+<!--        where account=#{account} and is_deleted=0-->
+<!--        limit 1;-->
+<!--    </select>-->
+
     <select id="isNicknameAlreadyUsed" resultType="Integer">
         select count(*)
         from koin.users
@@ -493,10 +497,10 @@
         WHERE NICKNAME = #{nickname} AND IS_DELETED = 0;
     </select>
 
-    <select id="getUserByAccount" resultMap="UserDiscriminator">
+    <select id="getUserByEmail" resultMap="UserDiscriminator">
         SELECT *
         FROM koin.users
-        where account=#{account}
+        where email=#{email}
     </select>
 
     <select id="getUserTypeById" resultType="koreatech.in.domain.User.UserType">
@@ -509,26 +513,24 @@
 
     <insert id="insertUser" parameterType="koreatech.in.domain.User.User">
         INSERT INTO koin.users (
-        account,
+        email,
         password,
         name,
         nickname,
         gender,
         phone_number,
-        email,
         auth_token,
         auth_expired_at,
         is_authed,
         profile_image_url,
         user_type)
         VALUES (
-        #{account},
+        #{email},
         #{password},
         #{name},
         #{nickname},
         #{gender},
         #{phone_number},
-        #{email},
         #{auth_token},
         #{auth_expired_at},
         #{is_authed},


### PR DESCRIPTION
# Task: `Account` -> `Email` 로 대체

## 변경사항

- Controller, Service, Repository, Database 에서 account → email 로 대체

## API 변경사항

### User (Student, Owner 공통)

- 로그인 (`/user/login/`)
    - request body,  account → email
- 본인 정보 조회 (`/user/me`)
    - response, account → email

### Student

- 사용자 조회 (`/user/student/{id}`)
    - response, account → email
- 사용자 업데이트 `(/user/student/student/{id})`
    - request body, response의 account → email
- 회원가입 (`/user/student/register`)
    - request body, account → email

### Owner

- 사장님 회원가입 (`/owners/register` )
    - account 제거

### Admin

- 사용자 목록 조회 (`/admin/users`)
    - response, account → email
- 사용자 조회 (`/admin/users/{id}`)
    - response, account → email
- 사용자 업데이트 `(/admin/users/student/{id})`
    - request body, response의 account → email
- 로그인 (`/admin/user/login/`)
    - request body, account → email

- - -

flyway ~V69까지 작성.