### PR TITLE
Task:  Account→Email 테스트 위한 Uesr API 기능 완성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,17 +113,12 @@
             <version>1.4</version>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>mysql</groupId>-->
-<!--            <artifactId>mysql-connector-java</artifactId>-->
-<!--            <version>5.1.31</version>-->
-<!--        </dependency>-->
-
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.28</version>
+            <version>5.1.31</version>
         </dependency>
+
         <!--MailSender-->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,12 +113,17 @@
             <version>1.4</version>
         </dependency>
 
+<!--        <dependency>-->
+<!--            <groupId>mysql</groupId>-->
+<!--            <artifactId>mysql-connector-java</artifactId>-->
+<!--            <version>5.1.31</version>-->
+<!--        </dependency>-->
+
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.31</version>
+            <version>8.0.28</version>
         </dependency>
-
         <!--MailSender-->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -1,10 +1,22 @@
 package koreatech.in.controller;
 
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import koreatech.in.annotation.Auth;
 import koreatech.in.annotation.AuthExcept;
 import koreatech.in.annotation.ParamValid;
 import koreatech.in.annotation.ValidationGroups;
+import koreatech.in.domain.User.owner.Owner;
+import koreatech.in.domain.User.student.Student;
 import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
 import koreatech.in.dto.RequestDataInvalidResponse;
@@ -15,8 +27,6 @@ import koreatech.in.dto.normal.user.request.StudentRegisterRequest;
 import koreatech.in.dto.normal.user.request.UpdateUserRequest;
 import koreatech.in.dto.normal.user.response.LoginResponse;
 import koreatech.in.dto.normal.user.response.StudentResponse;
-import koreatech.in.domain.User.owner.Owner;
-import koreatech.in.domain.User.student.Student;
 import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.service.UserService;
@@ -27,14 +37,14 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import springfox.documentation.annotations.ApiIgnore;
-
-import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import java.util.HashMap;
-import java.util.Map;
 
 @Api(tags = "(Normal) User", description = "회원")
 @Auth(role = Auth.Role.USER)

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -77,8 +77,8 @@ public class AdminUserController {
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
     @RequestMapping(value = "/admin/users/{id}", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity getUser(@ApiParam(required = true) @PathVariable("id") int id) throws Exception {
-        return new ResponseEntity<User>(adminUserService.getUserForAdmin(id), HttpStatus.OK);
+    ResponseEntity<User> getUser(@ApiParam(required = true) @PathVariable("id") int id) throws Exception {
+        return new ResponseEntity<>(adminUserService.getUserForAdmin(id), HttpStatus.OK);
     }
 
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -91,11 +91,11 @@ public class AdminUserController {
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
     @RequestMapping(value = "/admin/users/student/{id}", method = RequestMethod.PUT)
     public @ResponseBody
-    ResponseEntity updateUser(@ApiParam(value = "(optional: portal_account, password, name, nickname, student_number, major, identity, is_graduated, phone_number, gender, is_authed)", required = false)
-                              @RequestBody @Validated(ValidationGroups.UpdateAdmin.class) Student student,
+    ResponseEntity updateUser(@ApiParam(value = "(optional: email, password, name, nickname, student_number, major, identity, is_graduated, phone_number, gender, is_authed)", required = false)
+                              @RequestBody @Validated(ValidationGroups.UpdateAdmin.class) UpdateUserRequest updateUserRequest,
                               BindingResult bindingResult, @ApiParam(required = true) @PathVariable("id") int id) throws Exception {
 
-        return new ResponseEntity<User>(adminUserService.updateStudentForAdmin(student, id), HttpStatus.CREATED);
+        return new ResponseEntity(adminUserService.updateStudentForAdmin(updateUserRequest, id), HttpStatus.CREATED);
     }
 
     @ApiOperation(value = "회원 삭제 (탈퇴 처리)", notes = "회원을 soft delete 합니다.", authorizations = {@Authorization("Authorization")})

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -21,7 +21,6 @@ import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
 import koreatech.in.dto.admin.user.request.LoginRequest;
 import koreatech.in.dto.admin.user.response.LoginResponse;
-import koreatech.in.dto.normal.user.request.UpdateUserRequest;
 import koreatech.in.service.admin.AdminUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -84,8 +83,8 @@ public class AdminUserController {
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})
     @RequestMapping(value = "/admin/users", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity getUserList(@ModelAttribute("criteria") Criteria criteria) throws Exception {
-        return new ResponseEntity<Map<String, Object>>(adminUserService.getUserListForAdmin(criteria), HttpStatus.OK);
+    ResponseEntity<Map<String, Object>> getUserList(@ModelAttribute("criteria") Criteria criteria) throws Exception {
+            return new ResponseEntity<>(adminUserService.getUserListForAdmin(criteria), HttpStatus.OK);
     }
 
     @ParamValid

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -21,6 +21,7 @@ import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
 import koreatech.in.dto.admin.user.request.LoginRequest;
 import koreatech.in.dto.admin.user.response.LoginResponse;
+import koreatech.in.dto.normal.user.request.UpdateUserRequest;
 import koreatech.in.service.admin.AdminUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/koreatech/in/domain/User/Domain.java
+++ b/src/main/java/koreatech/in/domain/User/Domain.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 @Getter
 public class Domain {
 
+    private static final String PORTAL_DOMAIN = "koreatech.ac.kr";
+
     private final String value;
 
     private Domain(String value) {
@@ -44,4 +46,9 @@ public class Domain {
             throw new BaseException(ExceptionInformation.EMAIL_DOMAIN_INVALID);
         }
     }
+
+    public Boolean isStudentEmail() {
+        return getValue().equals(PORTAL_DOMAIN);
+    }
+
 }

--- a/src/main/java/koreatech/in/domain/User/EmailAddress.java
+++ b/src/main/java/koreatech/in/domain/User/EmailAddress.java
@@ -51,6 +51,12 @@ public class EmailAddress {
         return domainStartIndex != NOT_FOUND_INDEX_VALUE;
     }
 
+    public void validatePortalEmail() {
+        if(domain.isStudentEmail().equals(false)) {
+            throw new BaseException(ExceptionInformation.EMAIL_DOMAIN_IS_NOT_PORTAL_DOMAIN);
+        }
+    }
+
     static class EmailValidator {
         public static final String LOCAL_PARTS_PATTERN = "^(?=.{1,64}@)[A-Za-z0-9\\+_-]+(\\.[A-Za-z0-9\\+_-]+)*@";
         public static final String DOMAIN_PATTERN = "[^-][A-Za-z0-9\\+-]+(\\.[A-Za-z0-9\\+-]+)*(\\.[A-Za-z]{2,})$";

--- a/src/main/java/koreatech/in/domain/User/Users.java
+++ b/src/main/java/koreatech/in/domain/User/Users.java
@@ -1,4 +1,12 @@
 package koreatech.in.domain.User;
 
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class Users {
+
+    private List<User> users;
 }

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -29,6 +29,7 @@ public enum ExceptionInformation {
     CERTIFICATION_CODE_ALREADY_COMPLETED("해당 이메일은 이미 인증 완료되었습니다.", 101011, HttpStatus.CONFLICT),
     CERTIFICATION_CODE_NOT_COMPLETED("해당 이메일은 인증되지 않았습니다.", 101012, HttpStatus.CONFLICT),
     EMAIL_DUPLICATED("이미 존재하는 이메일 주소입니다. 다른 이메일 주소를 사용해주세요.", 101013, HttpStatus.CONFLICT),
+    EMAIL_DOMAIN_IS_NOT_PORTAL_DOMAIN("한국기술교육대학교 포탈의 이메일 형식('koreatech.ac.kr')이 아닙니다.", 101014, HttpStatus.UNPROCESSABLE_ENTITY),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -29,7 +29,7 @@ public interface UserMapper {
     Integer isNicknameAlreadyUsed(String nickname);
     void updateUserIsAuthed(@Param("id")Integer id, @Param("isAuth")Boolean isAuth);
     void updateResetTokenAndResetTokenExpiredTime(@Param("id") Integer id, @Param("resetToken") String resetToken, @Param("resetTokenExpiredTime") Date resetTokenExpiredTime);
-    User getUserListForAdmin(@Param("cursor") int cursor, @Param("limit") int limit);
+    Users getUserListForAdmin(@Param("cursor") int cursor, @Param("limit") int limit);
 
 
     @Select("SELECT * FROM koin.admins WHERE USER_ID = #{id}")

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -102,6 +102,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     public LoginResponse login(LoginRequest request) throws Exception {
         User user = userMapper.getAuthedUserByEmail(request.getEmail());
 
+        // TODO 23.02.15. 박한수 user가 존재하지 않은 경우와 존재하되 is_authed만 false인 경우가 같이 처리됨 -> getUserByEmail (아직 sql문 작성 안됨)으로 유저를 가져와서, 1. null 체크 2. is_authed 체크로 다른 예외로 반환하기.
         if (user == null) {
             throw new BaseException(USER_NOT_FOUND);
         }

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -130,7 +130,8 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         Student student = request.toEntity(UserCode.UserIdentity.STUDENT.getIdentityType());
 
         EmailAddress studentEmail = EmailAddress.from(student.getEmail());
-        //TODO 23.02.13. 학교 폼인지 검증 추가
+        studentEmail.validatePortalEmail();
+
         checkInputDataDuplicationAndValidation(student);
         String anonymousNickname = "익명_" + (System.currentTimeMillis());
         student.setEmail(studentEmail.getEmailAddress());

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -21,7 +21,7 @@ public interface AdminUserService {
 
     Student createStudentForAdmin(Student student);
 
-    Student updateStudentForAdmin(Student user, int id);
+    StudentResponse updateStudentForAdmin(UpdateUserRequest updateUserRequest, int id);
 
     void deleteUser(Integer userId);
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -142,8 +142,7 @@ public class AdminUserServiceImpl implements AdminUserService {
         // 가입되어 있는 계정이거나, 메일 인증을 아직 하지 않은 경우 가입 요청중인 계정이 디비에 존재하는 경우 예외처리
         // TODO: 메일 인증 하지 않은 경우 조건 추가
         EmailAddress studentEmail = EmailAddress.from(student.getEmail());
-        //TODO 23.02.13. 학교 폼인지 검증 추가
-        //studentEmail.validatePortalEmail();
+        studentEmail.validatePortalEmail();
 
         if(userMapper.isEmailAlreadyExist(studentEmail).equals(true)){
             throw new NotFoundException(new ErrorMessage("already exists", 0));

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -195,9 +195,13 @@ public class AdminUserServiceImpl implements AdminUserService {
 
 
     @Override
-    public Student updateStudentForAdmin(Student student, int id) {
-        Student selectUser = studentMapper.getStudentById(id);
-
+    public StudentResponse updateStudentForAdmin(UpdateUserRequest updateUserRequest, int id) {
+        User user =  userMapper.getUserById(id);
+        if (!user.isStudent()) {
+            throw new NotFoundException(new ErrorMessage("User is not Student", 0));
+        }
+        Student selectUser = (Student) user;
+        Student student = updateUserRequest.toEntity();
         if(selectUser == null){
             throw new NotFoundException(new ErrorMessage("No User", 0));
         }
@@ -230,7 +234,7 @@ public class AdminUserServiceImpl implements AdminUserService {
         userMapper.updateUser(selectUser);
         studentMapper.updateStudent(selectUser);
 
-        return student;
+        return new StudentResponse(student);
     }
 
     @Override

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -122,7 +122,8 @@ public class AdminUserServiceImpl implements AdminUserService {
         //int totalPage = criteria.calcTotalPage(totalCount);
         Map<String, Object> map = new HashMap<>();
 
-        map.put("items", userMapper.getUserListForAdmin(criteria.getCursor(), criteria.getLimit()));
+        Users userListForAdmin = userMapper.getUserListForAdmin(criteria.getCursor(), criteria.getLimit());
+        map.put("items", userListForAdmin);
         //map.put("totalPage", totalPage);
 
         return map;

--- a/src/main/resources/mapper/normal/StudentMapper.xml
+++ b/src/main/resources/mapper/normal/StudentMapper.xml
@@ -45,25 +45,25 @@
     </delete>
 
     <resultMap id="studentResult" extends="userResultMap" type="koreatech.in.domain.User.student.Student">
-        <result property="anonymousNickname" column="anonymous_nickname"/>
-        <result property="studentNumber" column="student_number"/>
+        <result property="anonymous_nickname" column="anonymous_nickname"/>
+        <result property="student_number" column="student_number"/>
         <result property="major" column="major"/>
-        <result property="isGraduated" column="is_graduated"/>
+        <result property="is_graduated" column="is_graduated"/>
     </resultMap>
 
     <resultMap id="userResultMap" type="koreatech.in.domain.User.User">
         <id property="id" column="id"/>
-        <result property="phoneNumber" column="phone_number"/>
-        <result property="userType" column="user_type"/>
-        <result property="isAuthed" column="is_authed"/>
-        <result property="lastLoggedAt" column="last_logged_at"/>
-        <result property="isDeleted" column="is_deleted"/>
-        <result property="createdAt" column="created_at"/>
-        <result property="updatedAt" column="updated_at"/>
-        <result property="profileImageUrl" column="profile_image_url"/>
-        <result property="authToken" column="auth_token"/>
-        <result property="authExpiredAt" column="auth_expired_at"/>
-        <result property="resetToken" column="reset_token"/>
-        <result property="resetExpiredAt" column="reset_expired_at"/>
+        <result property="phone_number" column="phone_number"/>
+        <result property="user_type" column="user_type"/>
+        <result property="is_authed" column="is_authed"/>
+        <result property="last_logged_at" column="last_logged_at"/>
+        <result property="is_deleted" column="is_deleted"/>
+        <result property="created_at" column="created_at"/>
+        <result property="updated_at" column="updated_at"/>
+        <result property="profile_image_url" column="profile_image_url"/>
+        <result property="auth_token" column="auth_token"/>
+        <result property="auth_expired_at" column="auth_expired_at"/>
+        <result property="reset_token" column="reset_token"/>
+        <result property="reset_expired_at" column="reset_expired_at"/>
     </resultMap>
 </mapper>

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -454,11 +454,74 @@
                 AND `t4`.`is_deleted` = 0
     </select>
 
+    <select id="getUserById" parameterType="Integer" resultMap="UserDiscriminator">
+        SELECT
+            `t1`.`id` AS `users.id`,
+            `t1`.`email` AS `users.email`,
+            `t1`.`password` AS `users.password`,
+            `t1`.`nickname` AS `users.nickname`,
+            `t1`.`name` AS `users.name`,
+            `t1`.`phone_number` AS `users.phone_number`,
+            `t1`.`user_type` AS `users.user_type`,
+            `t1`.`gender` AS `users.gender`,
+            `t1`.`is_authed` AS `users.is_authed`,
+            `t1`.`last_logged_at` AS `users.last_logged_at`,
+            `t1`.`profile_image_url` AS `users.profile_image_url`,
+            `t1`.`auth_token` AS `users.auth_token`,
+            `t1`.`auth_expired_at` AS `users.auth_expired_at`,
+            `t1`.`reset_token` AS `users.reset_token`,
+            `t1`.`reset_expired_at` AS `users.reset_expired_at`,
+            `t1`.`is_deleted` AS `users.is_deleted`,
+            `t1`.`created_at` AS `users.created_at`,
+            `t1`.`updated_at` AS `users.updated_at`,
 
+            `t2`.`anonymous_nickname` AS `students.anonymous_nickname`,
+            `t2`.`student_number` AS `students.student_number`,
+            `t2`.`major` AS `students.major`,
+            `t2`.`identity` AS `students.identity`,
+            `t2`.`is_graduated` AS `students.is_graduated`,
 
-    <select id="getUserById" resultMap="UserDiscriminator">
-        SELECT * FROM koin.users WHERE ID = #{id};
+            `t3`.`company_registration_number` AS `owners.company_registration_number`,
+            `t3`.`grant_shop` AS `owners.grant_shop`,
+            `t3`.`grant_event` AS `owners.grant_event`,
+
+            `t4`.`id` AS `admins.id`,
+            `t4`.`user_id` AS `admins.user_id`,
+            `t4`.`grant_user` AS `admins.grant_user`,
+            `t4`.`grant_callvan` AS `admins.grant_callvan`,
+            `t4`.`grant_land` AS `admins.grant_land`,
+            `t4`.`grant_community` AS `admins.grant_community`,
+            `t4`.`grant_shop` AS `admins.grant_shop`,
+            `t4`.`grant_version` AS `admins.grant_version`,
+            `t4`.`grant_market` AS `admins.grant_market`,
+            `t4`.`grant_circle` AS `admins.grant_circle`,
+            `t4`.`grant_lost` AS `admins.grant_lost`,
+            `t4`.`grant_survey` AS `admins.grant_survey`,
+            `t4`.`grant_bcsdlab` AS `admins.grant_bcsdlab`,
+            `t4`.`grant_event` AS `admins.grant_event`,
+            `t4`.`is_deleted` AS `admins.is_deleted`,
+            `t4`.`created_at` AS `admins.created_at`,
+            `t4`.`updated_at` AS `admins.updated_at`
+
+        FROM (
+                 SELECT *
+                 FROM `koin`.`users`
+                 WHERE
+                     id = #{id}
+             ) `t1`
+
+                 LEFT JOIN `koin`.`students` `t2`
+                           ON `t1`.`id` = `t2`.`user_id`
+
+                 LEFT JOIN `koin`.`owners` `t3`
+                           ON `t1`.`id` = `t3`.`user_id`
+
+                 LEFT JOIN `koin`.`admins` `t4`
+                           ON
+                                       `t1`.`id` = `t4`.`user_id`
+                                   AND `t4`.`is_deleted` = 0
     </select>
+<!--    UserResultMap 으로는 getUserById의 result 와 매핑이 안됨. (users.field) 꼴이기 떄문-->
 
     <select id="getTotalCount" resultType="Integer">
         SELECT COUNT(*) AS totalCount FROM koin.users WHERE IS_DELETED = 0;

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -527,10 +527,70 @@
         SELECT COUNT(*) AS totalCount FROM koin.users WHERE IS_DELETED = 0;
     </select>
 
-    <select id="getUserListForAdmin" resultMap="UserDiscriminator">
-        SELECT *
-        FROM koin.users
-        ORDER BY created_at LIMIT #{cursor}, #{limit};
+    <select id="getUserListForAdmin" resultMap="UsersResultMap">
+        SELECT
+            `t1`.`id` AS `users.id`,
+            `t1`.`email` AS `users.email`,
+            `t1`.`password` AS `users.password`,
+            `t1`.`nickname` AS `users.nickname`,
+            `t1`.`name` AS `users.name`,
+            `t1`.`phone_number` AS `users.phone_number`,
+            `t1`.`user_type` AS `users.user_type`,
+            `t1`.`gender` AS `users.gender`,
+            `t1`.`is_authed` AS `users.is_authed`,
+            `t1`.`last_logged_at` AS `users.last_logged_at`,
+            `t1`.`profile_image_url` AS `users.profile_image_url`,
+            `t1`.`auth_token` AS `users.auth_token`,
+            `t1`.`auth_expired_at` AS `users.auth_expired_at`,
+            `t1`.`reset_token` AS `users.reset_token`,
+            `t1`.`reset_expired_at` AS `users.reset_expired_at`,
+            `t1`.`is_deleted` AS `users.is_deleted`,
+            `t1`.`created_at` AS `users.created_at`,
+            `t1`.`updated_at` AS `users.updated_at`,
+
+            `t2`.`anonymous_nickname` AS `students.anonymous_nickname`,
+            `t2`.`student_number` AS `students.student_number`,
+            `t2`.`major` AS `students.major`,
+            `t2`.`identity` AS `students.identity`,
+            `t2`.`is_graduated` AS `students.is_graduated`,
+
+            `t3`.`company_registration_number` AS `owners.company_registration_number`,
+            `t3`.`grant_shop` AS `owners.grant_shop`,
+            `t3`.`grant_event` AS `owners.grant_event`,
+
+            `t4`.`id` AS `admins.id`,
+            `t4`.`user_id` AS `admins.user_id`,
+            `t4`.`grant_user` AS `admins.grant_user`,
+            `t4`.`grant_callvan` AS `admins.grant_callvan`,
+            `t4`.`grant_land` AS `admins.grant_land`,
+            `t4`.`grant_community` AS `admins.grant_community`,
+            `t4`.`grant_shop` AS `admins.grant_shop`,
+            `t4`.`grant_version` AS `admins.grant_version`,
+            `t4`.`grant_market` AS `admins.grant_market`,
+            `t4`.`grant_circle` AS `admins.grant_circle`,
+            `t4`.`grant_lost` AS `admins.grant_lost`,
+            `t4`.`grant_survey` AS `admins.grant_survey`,
+            `t4`.`grant_bcsdlab` AS `admins.grant_bcsdlab`,
+            `t4`.`grant_event` AS `admins.grant_event`,
+            `t4`.`is_deleted` AS `admins.is_deleted`,
+            `t4`.`created_at` AS `admins.created_at`,
+            `t4`.`updated_at` AS `admins.updated_at`
+
+        FROM (
+                 SELECT *
+                 FROM `koin`.`users`
+                 ORDER BY created_at LIMIT #{cursor}, #{limit}
+             ) `t1`
+
+                 LEFT JOIN `koin`.`students` `t2`
+                           ON `t1`.`id` = `t2`.`user_id`
+                 LEFT JOIN `koin`.`owners` `t3`
+                           ON `t1`.`id` = `t3`.`user_id`
+
+                 LEFT JOIN `koin`.`admins` `t4`
+                           ON
+                                       `t1`.`id` = `t4`.`user_id`
+                                   AND `t4`.`is_deleted` = 0
     </select>
 
     <select id="isAccountAlreadyUsed" resultType="Integer">


### PR DESCRIPTION
# Task: `Account`→`Email` 테스트 위한 Uesr API 기능 완성

## 변경사항

**추가된 기능들**

- Student 관련 로직, 이메일이 Portal Email (`~@koreatech.ac.kr`) 인지 검증하는 로직 추가

**이용 가능하도록 변경한 API들**

- `StudentMapper`
    - `getStudentById`
- AdminUser API
    - 조회(`GET /{id}`) 기능
    - 리스트 조회 기능 (GET `/users`}
    - 변경(`PUT /{id}`) 기능
- AdminUser API, User API
    - 조회(`GET /{id}`) 기능
    - 변경(`PUT /{id}`) 기능

## 구현내용

**추가된 기능들**

- Student 관련 로직, 이메일이 Portal Email (`~@koreatech.ac.kr`) 인지 검증하는 로직
    - EmailAddress에 검증 로직(`validatePortalEmail`) 추가

**이용 가능하도록 변경한 API들**

- `StudentMapper`
    - `getStudentById`
- AdminUser API
    - 조회(`GET /{id}`) 기능
    - 리스트 조회 기능 (GET `/users`}
    - 변경(`PUT /{id}`) 기능
- AdminUser API, User API
    - 조회(`GET /{id}`) 기능
    - 변경(`PUT /{id}`) 기능
    
- `UserMapper` 기능 완성
    - `getUserById` 기능
    - `getUserListForAdmin` 기능