### PR TITLE
Feature: 파일 업로드 API 확장

### DIFF
--- a/src/main/java/koreatech/in/controller/UploadController.java
+++ b/src/main/java/koreatech/in/controller/UploadController.java
@@ -14,6 +14,7 @@ import koreatech.in.annotation.ApiOff;
 import koreatech.in.annotation.Auth;
 import koreatech.in.domain.Upload.DomainEnum;
 import koreatech.in.dto.ExceptionResponse;
+import koreatech.in.dto.RequestDataInvalidResponse;
 import koreatech.in.dto.normal.upload.request.UploadFileRequest;
 import koreatech.in.dto.normal.upload.request.UploadFilesRequest;
 import koreatech.in.dto.normal.upload.response.UploadFileResponse;
@@ -139,7 +140,7 @@ public class UploadController {
                     + "(error code: 110000)", response = ExceptionResponse.class),
             @ApiResponse(code = 422, message = "- 유효하지 않은 파일일 때"
                     + "(error code: 110001) \n" + "- 파일목록이 비어있을 때 \n"
-                    + "(error code: 110002)", response = ExceptionResponse.class),
+                    + "(error code: 110002)", response = RequestDataInvalidResponse.class),
             @ApiResponse(code = 409, message = "파일들의 개수가 최대 개수를 초과하였을 때 \n"
                     + "(error code: 110003)", response = ExceptionResponse.class),
             @ApiResponse(code = 413, message = "도메인의 허용가능한 크기보다 파일의 크기가 클 때 \n"

--- a/src/main/java/koreatech/in/domain/Upload/ContentType.java
+++ b/src/main/java/koreatech/in/domain/Upload/ContentType.java
@@ -34,6 +34,15 @@ public class ContentType {
         }
     }
 
+    public boolean isAcceptable(ContentType candidate) {
+        try {
+            validateAcceptable(candidate);
+        } catch (BaseException exception) {
+            return false;
+        }
+        return true;
+    }
+
     private boolean isTypeWildCard() {
         return type.equals(WILD_CARD);
     }
@@ -72,6 +81,7 @@ public class ContentType {
     }
 
     public static ContentType ALL = from("*/*");
+    public static ContentType PDF = from("application/pdf");
     public static ContentType DEFAULT = ALL;
     public static ContentType IMAGE_ALL = from("image/*");
 }

--- a/src/main/java/koreatech/in/domain/Upload/ContentTypes.java
+++ b/src/main/java/koreatech/in/domain/Upload/ContentTypes.java
@@ -1,0 +1,30 @@
+package koreatech.in.domain.Upload;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+import java.util.List;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ContentTypes {
+
+    private final List<ContentType> contentTypes;
+
+    public static ContentTypes from(List<ContentType> contentTypes) {
+        return new ContentTypes(contentTypes);
+    }
+
+    public void validateAcceptable(ContentType candidate) {
+        contentTypes.stream()
+                .filter(c -> c.isAcceptable(candidate)).findAny()
+                .orElseThrow(() -> new BaseException(ExceptionInformation.UNEXPECTED_FILE_CONTENT_TYPE));
+    }
+
+    public static ContentTypes ALL = from(singletonList(ContentType.ALL));
+    public static ContentTypes DEFAULT = ALL;
+    public static ContentTypes IMAGE_ALL = from(singletonList(ContentType.IMAGE_ALL));
+    public static ContentTypes OWNER_LIMIT = from(asList(ContentType.IMAGE_ALL, ContentType.PDF));
+}

--- a/src/main/java/koreatech/in/domain/Upload/DomainEnum.java
+++ b/src/main/java/koreatech/in/domain/Upload/DomainEnum.java
@@ -12,14 +12,14 @@ import org.springframework.web.multipart.MultipartFile;
 public enum DomainEnum {
 
 
-    ITEMS(), LANDS(), CIRCLES(), MARKET(), SHOPS(), MEMBERS(), OWNERS(ContentType.IMAGE_ALL, ByteSize.OWNER_MAX_SIZE);
+    ITEMS(), LANDS(), CIRCLES(), MARKET(), SHOPS(), MEMBERS(), OWNERS(ContentTypes.OWNER_LIMIT, ByteSize.OWNER_MAX_SIZE);
 
-    private final ContentType expectContentType;
+    private final ContentTypes expectContentTypes;
     private final ByteSize limitedSize;
 
 
     DomainEnum() {
-        expectContentType = ContentType.DEFAULT ;
+        expectContentTypes = ContentTypes.DEFAULT ;
         limitedSize = ByteSize.DEFAULT;
     }
 
@@ -32,7 +32,7 @@ public enum DomainEnum {
     public void validateFor(MultipartFile multipartFile) {
         validates(multipartFile);
 
-        expectContentType.validateAcceptable(ContentType.from(multipartFile.getContentType()));
+        expectContentTypes.validateAcceptable(ContentType.from(multipartFile.getContentType()));
         limitedSize.validateAcceptable(ByteSize.from(multipartFile.getSize()));
     }
 


### PR DESCRIPTION
## 파일 업로드 API 확장

### 변경 사항

파일 업로드시, 각각 파일의 콘텐츠 타입과 파일 크기를 제한 가능하도록 설정

- 모든 도메인의 제한을 기본 값(콘텐츠 타입: `*/*` , 파일 크기(각각): 최대 `10MB`)으로 설정
- `owners` 도메인의 제한을 콘텐츠 타입 `pdf`, `image/*`, 파일 크기(각각): 최대 `10MB`으로 설정
- 위 두 제한 사항 Swagger에 명시하였습니다.

### **구현 사항**

- `ContentType` 목록을 저장하는 `ContentTypes` 객체 정의
    - 다양한 `ContentType` 을 받을 수 있도록 하기 위함
    
    e.g. `application/pdf` + `image/*`  저장
    
- `ContentTypes` 의`validateFor` 메서드를 통해 파일 유효 검증