### PR TITLE
Refactor: 닉네임 중복 체크 API

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -21,6 +21,7 @@ import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.service.UserService;
 import koreatech.in.util.StringXssChecker;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -145,10 +146,25 @@ public class UserController {
     ResponseEntity<EmptyResponse> checkUserNickname(
             @ApiParam(value = "닉네임 \n " +
                               "- not null \n " +
-                              "- 1자 이상 10자 이하 \n " +
+                              "- 10자 이하 \n " +
                               "- 공백 문자로만 이루어져있으면 안됨", required = true) @RequestParam("nickname") String nickname) throws Exception {
+        checkNicknameConstraintViolation(nickname);
+
         userService.checkUserNickname(nickname);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    // TODO: javax validation 으로 query parameter에 대한 제약조건 검사가 불가능하여 메소드로 만듬. 추후 검사 방법이 있을지 알아보기.
+    private void checkNicknameConstraintViolation(String nickname) {
+        if (nickname == null) {
+            throw new BaseException(ExceptionInformation.NICKNAME_SHOULD_NOT_BE_NULL);
+        }
+        if (nickname.length() > 10) {
+            throw new BaseException(ExceptionInformation.NICKNAME_MAXIMUM_LENGTH_IS_10);
+        }
+        if (StringUtils.isBlank(nickname)) {
+            throw new BaseException(ExceptionInformation.NICKNAME_MUST_NOT_BE_BLANK);
+        }
     }
 
     @ApiOperation(value = "비밀번호 초기화(변경) 메일 발송")

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -147,7 +147,7 @@ public class UserController {
             @ApiParam(value = "닉네임 \n " +
                               "- not null \n " +
                               "- 10자 이하 \n " +
-                              "- 공백 문자로만 이루어져있으면 안됨", required = true) @RequestParam("nickname") String nickname) throws Exception {
+                              "- 공백 문자로만 이루어져있으면 안됨", required = true) @RequestParam("nickname") String nickname) {
         checkNicknameConstraintViolation(nickname);
 
         userService.checkUserNickname(nickname);

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -137,7 +137,7 @@ public class UserController {
     @ApiOperation(value = "닉네임 중복 체크", notes = "닉네임 중복시 http status 409, 중복이 아닐시 http status 200을 응답합니다.")
     @ApiResponses({
             @ApiResponse(code = 409, message = "- 닉네임이 중복될 때 (code: 101002)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "- nickname의 제약 조건을 위반하였을 때 (code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "- nickname의 제약 조건을 위반하였을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @AuthExcept
     @RequestMapping(value = "/user/check/nickname/{nickname}", method = RequestMethod.GET)

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -140,13 +140,13 @@ public class UserController {
             @ApiResponse(code = 422, message = "- nickname의 제약 조건을 위반하였을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @AuthExcept
-    @RequestMapping(value = "/user/check/nickname/{nickname}", method = RequestMethod.GET)
+    @RequestMapping(value = "/user/check/nickname", method = RequestMethod.GET)
     public @ResponseBody
     ResponseEntity<EmptyResponse> checkUserNickname(
             @ApiParam(value = "닉네임 \n " +
                               "- not null \n " +
                               "- 1자 이상 10자 이하 \n " +
-                              "- 공백 문자로만 이루어져있으면 안됨", required = true) @PathVariable("nickname") String nickname) throws Exception {
+                              "- 공백 문자로만 이루어져있으면 안됨", required = true) @RequestParam("nickname") String nickname) throws Exception {
         userService.checkUserNickname(nickname);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -143,7 +143,7 @@ public class UserController {
     @AuthExcept
     @RequestMapping(value = "/user/check/nickname", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity<EmptyResponse> checkUserNickname(
+    ResponseEntity<EmptyResponse> checkDuplicationOfNickname(
             @ApiParam(value = "닉네임 \n " +
                               "- not null \n " +
                               "- 10자 이하 \n " +

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -253,7 +253,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public void checkUserNickname(String nickname) {
-        checkNicknameValid(nickname);
         checkNicknameDuplicated(nickname);
     }
 
@@ -391,22 +390,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
 
     private void deleteAccessTokenFromRedis(Integer userId) {
         stringRedisUtilStr.deleteData(redisLoginTokenKeyPrefix + userId.toString());
-    }
-
-
-    private void checkNicknameValid(String nickname) {
-        if (nickname == null) {
-            throw new BaseException(NICKNAME_SHOULD_NOT_BE_NULL);
-        }
-        if (nickname.length() == 0) {
-            throw new BaseException(NICKNAME_LENGTH_AT_LEAST_1);
-        }
-        if (StringUtils.isBlank(nickname)) {
-            throw new BaseException(NICKNAME_MUST_NOT_BE_BLANK);
-        }
-        if (nickname.length() > 10) {
-            throw new BaseException(NICKNAME_MAXIMUM_LENGTH_IS_10);
-        }
     }
 
     private void validateEmailUniqueness(EmailAddress emailAddress) {

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -253,7 +253,9 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public void checkUserNickname(String nickname) {
-        checkNicknameDuplicated(nickname);
+        if (userMapper.getUserByNickname(nickname) != null) {
+            throw new BaseException(NICKNAME_DUPLICATE);
+        }
     }
 
     @Override
@@ -395,14 +397,6 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     private void validateEmailUniqueness(EmailAddress emailAddress) {
         if(userMapper.isEmailAlreadyExist(emailAddress).equals(true)) {
             throw new BaseException(ExceptionInformation.EMAIL_DUPLICATED);
-        }
-    }
-
-    private void checkNicknameDuplicated(String nickname) {
-        User user = userMapper.getUserByNickname(nickname);
-
-        if (user != null && (user.isEmailAuthenticationCompleted() || user.isAwaitingEmailAuthentication())) {
-            throw new BaseException(NICKNAME_DUPLICATE);
         }
     }
 

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -291,7 +291,6 @@
             FROM `koin`.`users`
             WHERE
                 `nickname` = #{nickname}
-                AND `is_deleted` = 0
         ) `t1`
 
             LEFT JOIN `koin`.`students` `t2`


### PR DESCRIPTION
- 422 응답 response 타입 변경
- path variable 방식에서 query parameter 방식으로 변경
- 데이터 유효성 검증 계층을 service -> controller로 변경
- 기존에는 가입 대기(이메일 인증이 완료되지 않은 상태) 상태를 고려하여 중복 대상을 골라내는 방식이었지만, 닉네임으로 레코드가 조회되는지만 판별하여 중복 여부를 확인하는 방식으로 변경