### PR TITLE
Refactor: 비밀번호 찾기 요청 API

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -153,7 +153,7 @@ public class UserController {
 
     @ApiOperation(value = "비밀번호 초기화(변경) 메일 발송")
     @ApiResponses({
-            @ApiResponse(code = 401, message = "회원이 조회되지 않을 때 (code: 101000)", response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message = "이메일에 대한 회원이 조회되지 않을 때 (code: 101003)", response = ExceptionResponse.class),
             @ApiResponse(code = 422, message = "요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -154,7 +154,7 @@ public class UserController {
     @ApiOperation(value = "비밀번호 초기화(변경) 메일 발송")
     @ApiResponses({
             @ApiResponse(code = 401, message = "회원이 조회되지 않을 때 (code: 101000)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @ResponseStatus(HttpStatus.CREATED)
     @AuthExcept

--- a/src/main/java/koreatech/in/domain/User/User.java
+++ b/src/main/java/koreatech/in/domain/User/User.java
@@ -145,7 +145,7 @@ public class User {
         this.auth_expired_at = authExpiredAt;
     }
 
-    public void generateDataForFindPassword() {
+    public void generateResetTokenForFindPassword() {
         this.reset_expired_at = DateUtil.addHoursToJavaUtilDate(new Date(), 1);
         this.reset_token = SHA256Util.getEncrypt(this.email, this.reset_expired_at.toString());
     }

--- a/src/main/java/koreatech/in/dto/normal/user/request/FindPasswordRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/request/FindPasswordRequest.java
@@ -4,12 +4,15 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 
 @Getter @Setter
 public class FindPasswordRequest {
-    @NotNull(message = "account는 필수입니다.")
-    @ApiModelProperty(notes = "아이디 \n" +
-                              "- not null", example = "acsdefg1234", required = true)
-    private String account;
+    @NotNull(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이어야 합니다.")
+    @ApiModelProperty(notes = "이메일 \n" +
+                              "- not null \n" +
+                              "- 이메일 형식이어야 함", example = "abc123@test.com", required = true)
+    private String email;
 }

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package koreatech.in.service;
 import static koreatech.in.domain.DomainToMap.domainToMapWithExcept;
 import static koreatech.in.exception.ExceptionInformation.*;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.HashMap;
@@ -55,6 +56,8 @@ import org.springframework.ui.velocity.VelocityEngineUtils;
 @Service("userService")
 @Transactional
 public class UserServiceImpl implements UserService, UserDetailsService {
+
+    private static final String CHANGE_PASSWORD_FORM_LOCATION = "mail/change_password.vm";
 
     @Autowired
     private UserMapper userMapper;
@@ -361,13 +364,14 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     private void sendResetTokenByEmailForFindPassword(String resetToken, String contextPath, String email) {
-        Map<String, Object> model = new HashMap<>();
-        model.put("resetToken", resetToken);
-        model.put("contextPath", contextPath);
+        Map<String, Object> model = new HashMap<String, Object>() {{
+            put("resetToken", resetToken);
+            put("contextPath", contextPath);
+        }};
 
-        String text = VelocityEngineUtils.mergeTemplateIntoString(velocityEngine, "mail/change_password.vm", "UTF-8", model);
+        String text = VelocityEngineUtils.mergeTemplateIntoString(velocityEngine, CHANGE_PASSWORD_FORM_LOCATION, StandardCharsets.UTF_8.name(), model);
 
-        sesMailSender.sendMail("no-reply@bcsdlab.com", email, "코인 패스워드 초기화 인증", text);
+        sesMailSender.sendMail(SesMailSender.COMPANY_NO_REPLY_EMAIL_ADDRESS, email, SesMailSender.FIND_PASSWORD_SUBJECT, text);
     }
 
     private boolean isTokenExpired(Date expiredAt) {

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -1,13 +1,7 @@
 package koreatech.in.service;
 
 import static koreatech.in.domain.DomainToMap.domainToMapWithExcept;
-import static koreatech.in.exception.ExceptionInformation.NICKNAME_DUPLICATE;
-import static koreatech.in.exception.ExceptionInformation.NICKNAME_LENGTH_AT_LEAST_1;
-import static koreatech.in.exception.ExceptionInformation.NICKNAME_MAXIMUM_LENGTH_IS_10;
-import static koreatech.in.exception.ExceptionInformation.NICKNAME_MUST_NOT_BE_BLANK;
-import static koreatech.in.exception.ExceptionInformation.NICKNAME_SHOULD_NOT_BE_NULL;
-import static koreatech.in.exception.ExceptionInformation.PASSWORD_DIFFERENT;
-import static koreatech.in.exception.ExceptionInformation.USER_NOT_FOUND;
+import static koreatech.in.exception.ExceptionInformation.*;
 
 import java.sql.SQLException;
 import java.util.Date;
@@ -261,9 +255,8 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     @Override
     public void changePasswordConfig(FindPasswordRequest request, String host) {
         User user = userMapper.getAuthedUserByEmail(request.getEmail());
-
         if (user == null) {
-            throw new BaseException(USER_NOT_FOUND);
+            throw new BaseException(INQUIRED_USER_NOT_FOUND);
         }
 
         user.generateDataForFindPassword();

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -259,7 +259,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
             throw new BaseException(INQUIRED_USER_NOT_FOUND);
         }
 
-        user.generateDataForFindPassword();
+        user.generateResetTokenForFindPassword();
         userMapper.updateUser(user);
 
         sendResetTokenByEmailForFindPassword(user.getReset_token(), host, user.getEmail());

--- a/src/main/java/koreatech/in/util/SesMailSender.java
+++ b/src/main/java/koreatech/in/util/SesMailSender.java
@@ -8,6 +8,7 @@ public class SesMailSender {
 
     public static final String COMPANY_NO_REPLY_EMAIL_ADDRESS = "no-reply@bcsdlab.com";
     public static final String OWNER_EMAIL_VERIFICATION_SUBJECT = "코인 사장님 회원가입 이메일 인증";
+    public static final String FIND_PASSWORD_SUBJECT = "코인 패스워드 초기화 인증";
 
     @Autowired
     private AmazonSimpleEmailServiceAsync amazonSimpleEmailServiceAsync;

--- a/src/main/resources/mail/change_password.vm
+++ b/src/main/resources/mail/change_password.vm
@@ -47,7 +47,7 @@
             <table border="0" cellpadding="0" cellspacing="0" width="100%">
                 <tr>
                     <td width="75%" style="color:white; font-family: Arial, sans-serif;">
-                        Copyright BCSD Lab, TEAM_KAP All rights reserved.
+                        Copyright BCSD Lab All rights reserved.
                     </td>
 
                 </tr>


### PR DESCRIPTION
- `account` 대신 `email`을 요청받는 것으로 변경
- 매직 리터럴을 상수로 대체하여 적용