### PR TITLE
Refactor: 응답 & 요청 `Json`을 `snake_case` 로 변경

### DIFF
--- a/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
+++ b/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
@@ -1,5 +1,7 @@
 package koreatech.in.dto.global;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -8,6 +10,7 @@ import org.hibernate.validator.constraints.URL;
 
 @Getter
 @Setter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class AttachmentUrlRequest {
     @NotBlank
     @URL(protocol = "https", host = "static.koreatech.in"

--- a/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
+++ b/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
@@ -18,5 +18,5 @@ public class AttachmentUrlRequest {
             , required = true
             , example = "https://static.koreatech.in/assets/img/logo_white.png"
     )
-    private String fileUrl;
+    private String file_url;
 }

--- a/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
+++ b/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
@@ -18,5 +18,5 @@ public class AttachmentUrlRequest {
             , required = true
             , example = "https://static.koreatech.in/assets/img/logo_white.png"
     )
-    private String file_url;
+    private String fileUrl;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerRegisterRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerRegisterRequest.java
@@ -1,5 +1,7 @@
 package koreatech.in.dto.normal.user.owner.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import javax.validation.Valid;
@@ -15,6 +17,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class OwnerRegisterRequest extends UserRegisterRequest {
 
     @NotBlank(message = "이름은 필수입니다.")
@@ -47,5 +50,5 @@ public class OwnerRegisterRequest extends UserRegisterRequest {
             , required = true
     )
     @Valid
-    private List<AttachmentUrlRequest> companyCertificateAttachmentUrls;
+    private List<AttachmentUrlRequest> attachmentUrls;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerRegisterRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerRegisterRequest.java
@@ -35,7 +35,7 @@ public class OwnerRegisterRequest extends UserRegisterRequest {
             , example = "012-34-56789"
             , required = true
     )
-    private String company_number;
+    private String companyNumber;
 
     @NotNull(message = "이미지 첨부는 필수입니다.")
     @Size(min = 3, max = 5, message = "이미지는 사업자등록증, 영업신고증, 통장사본을 포함하여 최소 3개 최대 5개까지 가능합니다.")
@@ -47,5 +47,5 @@ public class OwnerRegisterRequest extends UserRegisterRequest {
             , required = true
     )
     @Valid
-    private List<AttachmentUrlRequest> attachment_urls;
+    private List<AttachmentUrlRequest> companyCertificateAttachmentUrls;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerRegisterRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerRegisterRequest.java
@@ -35,7 +35,7 @@ public class OwnerRegisterRequest extends UserRegisterRequest {
             , example = "012-34-56789"
             , required = true
     )
-    private String companyNumber;
+    private String company_number;
 
     @NotNull(message = "이미지 첨부는 필수입니다.")
     @Size(min = 3, max = 5, message = "이미지는 사업자등록증, 영업신고증, 통장사본을 포함하여 최소 3개 최대 5개까지 가능합니다.")
@@ -47,5 +47,5 @@ public class OwnerRegisterRequest extends UserRegisterRequest {
             , required = true
     )
     @Valid
-    private List<AttachmentUrlRequest> companyCertificateAttachmentUrls;
+    private List<AttachmentUrlRequest> attachment_urls;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyCodeRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyCodeRequest.java
@@ -24,5 +24,5 @@ public class VerifyCodeRequest {
     @ApiModelProperty(notes = "인증코드 \n" +
             "- not blank \n" +
             "- 6자리 정수여야 함", required = true)
-    private String certificationCode;
+    private String certification_code;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyCodeRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyCodeRequest.java
@@ -24,5 +24,5 @@ public class VerifyCodeRequest {
     @ApiModelProperty(notes = "인증코드 \n" +
             "- not blank \n" +
             "- 6자리 정수여야 함", required = true)
-    private String certification_code;
+    private String certificationCode;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyCodeRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyCodeRequest.java
@@ -1,5 +1,7 @@
 package koreatech.in.dto.normal.user.owner.request;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.Email;
@@ -10,6 +12,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class VerifyCodeRequest {
 
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -45,7 +45,7 @@ public interface OwnerConverter {
 
     @Mappings({
             @Mapping(source = "address", target = "email", qualifiedByName = "convertEmail"),
-            @Mapping(source = "certificationCode", target = "certificationCode")
+            @Mapping(source = "certification_code", target = "certificationCode")
     })
     OwnerInCertification toOwnerInCertification(VerifyCodeRequest verifyCodeRequest);
 
@@ -64,14 +64,14 @@ public interface OwnerConverter {
     User toUser(UserRegisterRequest userRegisterRequest);
 
     @Mappings({
-            @Mapping(source = "companyCertificateAttachmentUrls", target = "attachments", qualifiedByName = "convertAttachments"),
-            @Mapping(source = "companyNumber", target = "company_registration_number"),
+            @Mapping(source = "attachment_urls", target = "attachments", qualifiedByName = "convertAttachments"),
+            @Mapping(source = "company_number", target = "company_registration_number"),
     })
     Owner toOwner(OwnerRegisterRequest ownerRegisterRequest);
 
     @Named("convertAttachments")
     default List<String> convertAttachments(List<AttachmentUrlRequest> companyCertificateAttachmentUrls) {
-        return companyCertificateAttachmentUrls.stream().map(AttachmentUrlRequest::getFileUrl)
+        return companyCertificateAttachmentUrls.stream().map(AttachmentUrlRequest::getFile_url)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -45,7 +45,7 @@ public interface OwnerConverter {
 
     @Mappings({
             @Mapping(source = "address", target = "email", qualifiedByName = "convertEmail"),
-            @Mapping(source = "certification_code", target = "certificationCode")
+            @Mapping(source = "certificationCode", target = "certificationCode")
     })
     OwnerInCertification toOwnerInCertification(VerifyCodeRequest verifyCodeRequest);
 
@@ -64,14 +64,14 @@ public interface OwnerConverter {
     User toUser(UserRegisterRequest userRegisterRequest);
 
     @Mappings({
-            @Mapping(source = "attachment_urls", target = "attachments", qualifiedByName = "convertAttachments"),
-            @Mapping(source = "company_number", target = "company_registration_number"),
+            @Mapping(source = "companyCertificateAttachmentUrls", target = "attachments", qualifiedByName = "convertAttachments"),
+            @Mapping(source = "companyNumber", target = "company_registration_number"),
     })
     Owner toOwner(OwnerRegisterRequest ownerRegisterRequest);
 
     @Named("convertAttachments")
     default List<String> convertAttachments(List<AttachmentUrlRequest> companyCertificateAttachmentUrls) {
-        return companyCertificateAttachmentUrls.stream().map(AttachmentUrlRequest::getFile_url)
+        return companyCertificateAttachmentUrls.stream().map(AttachmentUrlRequest::getFileUrl)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -64,7 +64,7 @@ public interface OwnerConverter {
     User toUser(UserRegisterRequest userRegisterRequest);
 
     @Mappings({
-            @Mapping(source = "companyCertificateAttachmentUrls", target = "attachments", qualifiedByName = "convertAttachments"),
+            @Mapping(source = "attachmentUrls", target = "attachments", qualifiedByName = "convertAttachments"),
             @Mapping(source = "companyNumber", target = "company_registration_number"),
     })
     Owner toOwner(OwnerRegisterRequest ownerRegisterRequest);


### PR DESCRIPTION
## 요청/응답을 스네이크 케이스로 처리하도록 변경

기존에 본인이 만들었던 요청/응답 중 카멜 케이스로 적용된 것들이 있어, 스네이크 케이스로 처리하도록 변경함.

**해당 변경사항**

- **POST /owners/register**
    - 요청 (→ snake_case)
- **POST /owners/verification/code**
    - 요청 (→ snake_case)

**코드 구현사항**

`@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)` 을 이용하여 처리

**기타 변경사항**

**POST /owners/register** 에서 사용하는 `companyCertificateAttachmentUrls` →  `attachment_urls`로 축약