### PR TITLE
Fix: url validation stage도 가능하도록 변경

### DIFF
--- a/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
+++ b/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
@@ -12,8 +12,9 @@ import org.hibernate.validator.constraints.URL;
 @Setter
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class AttachmentUrlRequest {
+//    public static final String STATIC_KOREATECH_IN = "static.koreatech.in";
     @NotBlank
-    @URL(protocol = "https", host = "static.koreatech.in"
+    @URL(protocol = "https", regexp = ".*static\\.koreatech\\.in.*"
             , message = "코인 파일 저장 형식이 아닙니다.")
     @ApiModelProperty(notes = " \n"
             + "- not blank \n"


### PR DESCRIPTION
**변경 내용**
기존 Url validation이 `static.koreatech.in` (production upload url) 만 가능하도록 되어있어,

이를 `stage-static.koreatech.in` (stage upload url)도 가능하도록 변경

**코드 변경 사항**
regax 이용하여 어디든 `static.koreatech.in` 만 붙어있으면 유효하다 판단하도록 변경

