### PR TITLE
Refactor: Attachment 클래스 추출

### DIFF
--- a/src/main/java/koreatech/in/domain/User/owner/Attachment.java
+++ b/src/main/java/koreatech/in/domain/User/owner/Attachment.java
@@ -1,0 +1,37 @@
+package koreatech.in.domain.User.owner;
+
+import koreatech.in.domain.Upload.UploadFileFullName;
+import koreatech.in.domain.Upload.UploadFileFullPath;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class Attachment {
+    private final String fileUrl;
+    private final String fileName;
+
+    public static Attachment from(String fileUrl) {
+        return new Attachment(fileUrl, fileNameFor(fileUrl));
+    }
+
+    private static String fileNameFor(String fileUrl) {
+        //TODO 23.02.25. 박한수 해당 위치에서, 파일 도메인이 `owners`인지 검사를 추가해야 할지..?
+        String separator = UploadFileFullPath.SLASH;
+        int separateIndex = fileUrl.lastIndexOf(separator);
+
+        if (separateIndex == UploadFileFullName.NOT_FOUND_INDEX) {
+            throw new BaseException(ExceptionInformation.UPLOAD_FILE_URL_INVALID);
+        }
+
+        return fileUrl.substring(separateIndex + separator.length());
+    }
+
+}

--- a/src/main/java/koreatech/in/domain/User/owner/Attachment.java
+++ b/src/main/java/koreatech/in/domain/User/owner/Attachment.java
@@ -16,10 +16,9 @@ import lombok.ToString;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class Attachment {
     private final String fileUrl;
-    private final String fileName;
 
     public static Attachment from(String fileUrl) {
-        return new Attachment(fileUrl, fileNameFor(fileUrl));
+        return new Attachment(fileUrl);
     }
 
     private static String fileNameFor(String fileUrl) {

--- a/src/main/java/koreatech/in/domain/User/owner/Owner.java
+++ b/src/main/java/koreatech/in/domain/User/owner/Owner.java
@@ -12,7 +12,7 @@ import lombok.ToString;
 @NoArgsConstructor
 public class Owner extends User {
     private String company_registration_number;
-    private List<String> attachments;
+    private List<Attachment> attachments;
     // Todo grant 들 별도의 Grant embedded 객체로 매핑
     private Boolean grant_shop;
     private Boolean grant_event;

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerAttachment.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerAttachment.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Getter @Setter
 @NoArgsConstructor
-public class OwnerShopAttachment {
+public class OwnerAttachment {
 
     private Integer id;
     private Integer ownerId;
@@ -16,12 +16,12 @@ public class OwnerShopAttachment {
     private Boolean isDeleted;
     private Date updateAt;
 
-    public static OwnerShopAttachment of(Integer ownerId, String url) {
-        OwnerShopAttachment ownerShopAttachment = new OwnerShopAttachment();
-        ownerShopAttachment.setOwnerId(ownerId);
-        ownerShopAttachment.setUrl(url);
+    public static OwnerAttachment of(Integer ownerId, String url) {
+        OwnerAttachment ownerAttachment = new OwnerAttachment();
+        ownerAttachment.setOwnerId(ownerId);
+        ownerAttachment.setUrl(url);
 
-        return ownerShopAttachment;
+        return ownerAttachment;
     }
 
 }

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerAttachment.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerAttachment.java
@@ -12,14 +12,14 @@ public class OwnerAttachment {
     private Integer id;
     private Integer ownerId;
     private Integer shopId;
-    private String url;
+    private String fileUrl;
     private Boolean isDeleted;
     private Date updateAt;
 
-    public static OwnerAttachment of(Integer ownerId, String url) {
+    public static OwnerAttachment of(Integer ownerId, String fileUrl) {
         OwnerAttachment ownerAttachment = new OwnerAttachment();
         ownerAttachment.setOwnerId(ownerId);
-        ownerAttachment.setUrl(url);
+        ownerAttachment.setFileUrl(fileUrl);
 
         return ownerAttachment;
     }

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
@@ -6,6 +6,6 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class OwnerShopAttachments {
-    private List<OwnerShopAttachment> attachments;
+public class OwnerAttachments {
+    private List<OwnerAttachment> attachments;
 }

--- a/src/main/java/koreatech/in/dto/normal/upload/response/UploadFileResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/upload/response/UploadFileResponse.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class UploadFileResponse {
     @ApiModelProperty(notes = "업로드된 파일 url",
-            example = "https://static.koreatech.in/example.png",
+            example = "static.koreatech.in/example.png",
             required = true
     )
     private final String fileUrl;

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -1,6 +1,7 @@
 package koreatech.in.exception;
 
 import lombok.Getter;
+import org.hibernate.validator.constraints.URL;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -58,7 +59,7 @@ public enum ExceptionInformation {
     // ======= 파일 업로드 =======
     DOMAIN_NOT_FOUND("존재하지 않는 도메인입니다.", 110000, HttpStatus.NOT_FOUND),
     FILE_INVALID("유효하지 않는 파일입니다.", 110001, HttpStatus.UNPROCESSABLE_ENTITY),
-    //TODO 23.02.11. 박한수 파일목록(List<File~>) 을 멤버로 하는 객체 선언해서, 이 객체로 ResponseBody가 매핑되어 ParamValid에 걸릴 수 있는지 시도해보기.
+    //TODO 23.02.11. 박한수 파일 업로드 API에서, 파일목록(List<File~>) {다중 파일 업로드시 request body에 매핑되는 collection} 을 list를 필드로 갖는 객체로 변경하여, 이 객체에 annotation validation을 적용할 수 있는지 보기.
     FILES_EMPTY("파일목록이 비어있습니다.", 110002, HttpStatus.UNPROCESSABLE_ENTITY),
     FILES_LENGTH_OVER("파일목록의 길이가 최대보다 큽니다.", 110003, HttpStatus.CONFLICT),
     UNEXPECTED_FILE_CONTENT_TYPE("도메인이 허용하지 않는 콘텐츠 타입입니다.", 110004, HttpStatus.UNSUPPORTED_MEDIA_TYPE),
@@ -88,7 +89,8 @@ public enum ExceptionInformation {
     TIME_INFORMATION_IS_REQUIRED_UNLESS_CLOSED("휴무가 아니라면 여는 시간과 닫는 시간 정보는 필수입니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
     DUPLICATE_DAY_OF_WEEK_INFORMATION_EXISTS("중복되는 요일이 존재합니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
     PRICE_OF_MENU_IS_REQUIRED("메뉴의 가격 정보는 필수입니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
-    DUPLICATE_OPTIONS_EXIST_IN_MENU("메뉴에서 중복되는 옵션명이 있습니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY);
+    DUPLICATE_OPTIONS_EXIST_IN_MENU("메뉴에서 중복되는 옵션명이 있습니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY),
+    UPLOAD_FILE_URL_INVALID("코인 파일 저장 형식(static.koreatech.in)이 아닙니다.", 100000, HttpStatus.UNPROCESSABLE_ENTITY);
 
     ExceptionInformation(String message, Integer code, HttpStatus httpStatus) {
         this.message = message;

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -2,10 +2,10 @@ package koreatech.in.mapstruct;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.Domain;
 import koreatech.in.domain.User.EmailAddress;
 import koreatech.in.domain.User.LocalParts;
+import koreatech.in.domain.User.owner.Attachment;
 import koreatech.in.domain.User.owner.Owner;
 import koreatech.in.domain.User.owner.OwnerInCertification;
 import koreatech.in.domain.User.owner.OwnerShopAttachment;
@@ -14,12 +14,10 @@ import koreatech.in.dto.global.AttachmentUrlRequest;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyEmailRequest;
-import koreatech.in.dto.normal.user.request.UserRegisterRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.Named;
-import org.mapstruct.SubclassMapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -54,24 +52,21 @@ public interface OwnerConverter {
         return EmailAddress.from(address).getEmailAddress();
     }
 
-
     @Mappings({
             @Mapping(source = "password", target = "password"),
             @Mapping(source = "email", target = "email"),
-            @Mapping(source = "name", target = "name")
-    })
-    @SubclassMapping(source = OwnerRegisterRequest.class, target = Owner.class)
-    User toUser(UserRegisterRequest userRegisterRequest);
+            @Mapping(source = "name", target = "name"),
 
-    @Mappings({
             @Mapping(source = "attachmentUrls", target = "attachments", qualifiedByName = "convertAttachments"),
             @Mapping(source = "companyNumber", target = "company_registration_number"),
     })
     Owner toOwner(OwnerRegisterRequest ownerRegisterRequest);
 
     @Named("convertAttachments")
-    default List<String> convertAttachments(List<AttachmentUrlRequest> companyCertificateAttachmentUrls) {
-        return companyCertificateAttachmentUrls.stream().map(AttachmentUrlRequest::getFileUrl)
+    default List<Attachment> convertAttachments(List<AttachmentUrlRequest> companyCertificateAttachmentUrls) {
+        return companyCertificateAttachmentUrls.stream().map(
+                        attachmentUrlRequest -> Attachment.from(attachmentUrlRequest.getFileUrl())
+                )
                 .collect(Collectors.toList());
     }
 
@@ -82,7 +77,7 @@ public interface OwnerConverter {
 
     @Named("convertAttachment")
     default List<OwnerShopAttachment> convertAttachment(Owner owner) {
-        return owner.getAttachments().stream().map(url -> OwnerShopAttachment.of(owner.getId(), url))
+        return owner.getAttachments().stream().map(attachment -> OwnerShopAttachment.of(owner.getId(), attachment.getFileUrl()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -8,8 +8,8 @@ import koreatech.in.domain.User.LocalParts;
 import koreatech.in.domain.User.owner.Attachment;
 import koreatech.in.domain.User.owner.Owner;
 import koreatech.in.domain.User.owner.OwnerInCertification;
-import koreatech.in.domain.User.owner.OwnerShopAttachment;
-import koreatech.in.domain.User.owner.OwnerShopAttachments;
+import koreatech.in.domain.User.owner.OwnerAttachment;
+import koreatech.in.domain.User.owner.OwnerAttachments;
 import koreatech.in.dto.global.AttachmentUrlRequest;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyCodeRequest;
@@ -73,11 +73,11 @@ public interface OwnerConverter {
     @Mappings({
             @Mapping(source = ".", target = "attachments", qualifiedByName = "convertAttachment")
     })
-    OwnerShopAttachments toOwnerShopAttachments(Owner owner);
+    OwnerAttachments toOwnerShopAttachments(Owner owner);
 
     @Named("convertAttachment")
-    default List<OwnerShopAttachment> convertAttachment(Owner owner) {
-        return owner.getAttachments().stream().map(attachment -> OwnerShopAttachment.of(owner.getId(), attachment.getFileUrl()))
+    default List<OwnerAttachment> convertAttachment(Owner owner) {
+        return owner.getAttachments().stream().map(attachment -> OwnerAttachment.of(owner.getId(), attachment.getFileUrl()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -1,7 +1,7 @@
 package koreatech.in.repository.user;
 
 import koreatech.in.domain.User.owner.Owner;
-import koreatech.in.domain.User.owner.OwnerShopAttachments;
+import koreatech.in.domain.User.owner.OwnerAttachments;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 import org.springframework.stereotype.Repository;
@@ -16,5 +16,5 @@ public interface OwnerMapper {
     void safeDeleteOwner(Owner owner);
     void deleteOwner(Integer id);
 
-    void insertOwnerShopAttachment(OwnerShopAttachments ownerShopAttachments);
+    void insertOwnerShopAttachment(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import koreatech.in.domain.User.EmailAddress;
-import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.UserType;
 import koreatech.in.domain.User.owner.CertificationCode;
 import koreatech.in.domain.User.owner.Owner;
@@ -94,7 +93,7 @@ public class OwnerServiceImpl implements OwnerService {
     public void register(OwnerRegisterRequest ownerRegisterRequest) {
 
         // TODO 23.02.12. 박한수 사업자등록번호 중복되는 경우 예외 처리 필요.
-        Owner owner = downcastFrom(OwnerConverter.INSTANCE.toUser(ownerRegisterRequest));
+        Owner owner = OwnerConverter.INSTANCE.toOwner(ownerRegisterRequest);
         EmailAddress ownerEmailAddress = EmailAddress.from(owner.getEmail());
 
         validateEmailUniqueness(ownerEmailAddress);
@@ -162,13 +161,6 @@ public class OwnerServiceImpl implements OwnerService {
 
         return VelocityEngineUtils.mergeTemplateIntoString(velocityEngine, OWNER_CERTIFICATE_FORM_LOCATION,
                 StandardCharsets.UTF_8.name(), model);
-    }
-
-    private static Owner downcastFrom(User user) {
-        if (!(user instanceof Owner)) {
-            throw new ClassCastException("OwnerConverter에서 User -> Owner로 변환 과정 중 잘못된 다운캐스팅이 발생했습니다.");
-        }
-        return (Owner) user;
     }
 
     private void encodePassword(Owner owner) {

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -9,18 +9,18 @@
                 #{company_registration_number});
     </insert>
 
-    <insert id="insertOwnerShopAttachment" parameterType="koreatech.in.domain.User.owner.OwnerShopAttachments">
+    <insert id="insertOwnerShopAttachment" parameterType="koreatech.in.domain.User.owner.OwnerAttachments">
         INSERT INTO koin.owner_shop_attachment (
         shop_id,
         owner_id,
         url
         )
         VALUES
-        <foreach item="ownerShopAttachment" collection="attachments" separator=",">
+        <foreach item="ownerAttachment" collection="attachments" separator=",">
             (
-            #{ownerShopAttachment.shopId},
-            #{ownerShopAttachment.ownerId},
-            #{ownerShopAttachment.url}
+            #{ownerAttachment.shopId},
+            #{ownerAttachment.ownerId},
+            #{ownerAttachment.url}
             )
         </foreach>
     </insert>


### PR DESCRIPTION
# Refactor: Attachment 클래스 추출

**배경**

사장님 객체의 첨부파일이 단순 url에서, 파일 명이라는 새로운 정보를 갖게 됨. (파일 명을 검증 &추출하는 로직도 생성이 필요)

이에 따라 파일명을 검증하고 추출하는 메서드도 필요하게 됨.

따라서 첨부파일에 관련된 필드와 메서드들을 별도 객체로 추출.

**요약**

Owner에 List안에 <String>형태로 존재하던 file_url을 별도 클래스인 Attachment로 추출.

**기능 변경사항**

X

**코드 구현사항**

- Converter-Service-Repository 에 `Owner` 관련 로직 변경

**기타 변경사항**

- swagger 예시 변경 (`https://[stage.koreatech.in/~](http://stage.koreatech.in/~)` → `stage.koreatech.in/~` )
- converter 로직 변경 (toUser 이후 다운캐스팅 → toOwner)

- - -

*의도치 않게, `feature/owner-read-api` 의 내용이 stage에 바로 push되어 변경사항 문서를 해당 PR에 같이 작성되었습니다.

# Feature: 사장님 정보 조회 API

**기능 변경사항**

- `GET /owner` API 생성

**코드 구현사항**

- `Controller`, `Service`, `Repository`에 `getOwner()` 메서드 생성 후 구현
- `Attachment` 객체 (이전 PR에서 생성한 객체) 대신 `OwnerAttachment` (기존에 있던 객체) 를 사용
