### PR TITLE
Refactor: 어드민 로그인/로그아웃 리팩토링

### DIFF
--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -51,7 +51,7 @@ public class AdminUserController {
     @ApiOperation("어드민 로그인")
     @ApiResponses({
             @ApiResponse(code = 401, message = "잘못된 접근일 때 (code: 100001) \n\n" +
-                                               "아이디에 대한 회원 정보가 없을 때 (code: 101000) \n\n" +
+                                               "이메일에 대한 회원 정보가 없을 때 (code: 101000) \n\n" +
                                                "비밀번호가 일치하지 않을 때 (code: 101001)", response = ExceptionResponse.class),
             @ApiResponse(code = 422, message = "요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -19,6 +19,7 @@ import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.student.Student;
 import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
+import koreatech.in.dto.RequestDataInvalidResponse;
 import koreatech.in.dto.admin.user.request.LoginRequest;
 import koreatech.in.dto.admin.user.request.NewOwnersCondition;
 import koreatech.in.dto.admin.user.response.LoginResponse;
@@ -52,7 +53,7 @@ public class AdminUserController {
             @ApiResponse(code = 401, message = "잘못된 접근일 때 (code: 100001) \n\n" +
                                                "아이디에 대한 회원 정보가 없을 때 (code: 101000) \n\n" +
                                                "비밀번호가 일치하지 않을 때 (code: 101001)", response = ExceptionResponse.class),
-            @ApiResponse(code = 422, message = "요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = ExceptionResponse.class)
+            @ApiResponse(code = 422, message = "요청 데이터 제약조건이 지켜지지 않았을 때 (code: 100000)", response = RequestDataInvalidResponse.class)
     })
     @AuthExcept
     @ParamValid

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -73,7 +73,7 @@ public class AdminUserController {
     })
     @RequestMapping(value = "/admin/user/logout", method = RequestMethod.POST)
     public ResponseEntity<EmptyResponse> logout() {
-        adminUserService.logoutForAdmin();
+        adminUserService.logout();
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -59,7 +59,7 @@ public class AdminUserController {
     @ParamValid
     @RequestMapping(value = "/admin/user/login", method = RequestMethod.POST)
     public ResponseEntity<LoginResponse> login(@RequestBody @Valid LoginRequest request, BindingResult bindingResult) throws Exception {
-        LoginResponse response = adminUserService.loginForAdmin(request);
+        LoginResponse response = adminUserService.login(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/koreatech/in/domain/User/User.java
+++ b/src/main/java/koreatech/in/domain/User/User.java
@@ -192,4 +192,8 @@ public class User {
         }
         return getUser_type().getText();
     }
+
+    public void updateLastLoginTimeToCurrent() {
+        this.last_logged_at = new Date();
+    }
 }

--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository;
 public interface UserMapper {
     User getAuthedUserById(@Param("id") Integer id);
     User getAuthedUserByEmail(@Param("email") String email);
-    void updateLastLoggedAt(@Param("id") Integer id, @Param("currentDate") Date currentDate);
     void deleteUser(@Param("user") User user);
     void undeleteUserLogicallyById(@Param("id") Integer id);
 

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -108,7 +108,8 @@ public class UserServiceImpl implements UserService, UserDetailsService {
             throw new BaseException(PASSWORD_DIFFERENT);
         }
 
-        userMapper.updateLastLoggedAt(user.getId(), new Date());
+        user.updateLastLoginTimeToCurrent();
+        userMapper.updateUser(user);
 
         String accessToken = getAccessTokenFromRedis(user);
         if (isTokenNotExistOrExpired(accessToken)) {

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -15,7 +15,7 @@ import koreatech.in.dto.normal.user.student.response.StudentResponse;
 public interface AdminUserService {
     LoginResponse login(LoginRequest request) throws Exception;
 
-    void logoutForAdmin();
+    void logout();
 
     Map<String, Object> getUserListForAdmin(Criteria criteria) throws Exception;
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -13,7 +13,7 @@ import koreatech.in.dto.normal.user.request.UpdateUserRequest;
 import koreatech.in.dto.normal.user.student.response.StudentResponse;
 
 public interface AdminUserService {
-    LoginResponse loginForAdmin(LoginRequest request) throws Exception;
+    LoginResponse login(LoginRequest request) throws Exception;
 
     void logoutForAdmin();
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -112,7 +112,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     }
 
     @Override
-    public void logoutForAdmin() {
+    public void logout() {
         User user = jwtValidator.validate();
         deleteAccessTokenFromRedis(user.getId());
     }

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -30,7 +30,6 @@ import koreatech.in.exception.NotFoundException;
 import koreatech.in.exception.PreconditionFailedException;
 import koreatech.in.repository.AuthorityMapper;
 import koreatech.in.repository.admin.AdminUserMapper;
-import koreatech.in.repository.user.OwnerMapper;
 import koreatech.in.repository.user.StudentMapper;
 import koreatech.in.repository.user.UserMapper;
 import koreatech.in.service.JwtValidator;
@@ -53,9 +52,6 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Autowired
     private StudentMapper studentMapper;
-
-    @Autowired
-    private OwnerMapper ownerMapper;
 
     @Autowired
     private AuthorityMapper authorityMapper;

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -77,7 +77,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     private String redisLoginTokenKeyPrefix;
 
     @Override
-    public LoginResponse loginForAdmin(LoginRequest request) throws Exception {
+    public LoginResponse login(LoginRequest request) throws Exception {
         final User user = userMapper.getAuthedUserByEmail(request.getEmail());
 
         if (user == null || !user.hasAuthority() /* 어드민 권한이 없으면 없는 회원으로 간주 */) {

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -5,7 +5,6 @@ import static koreatech.in.exception.ExceptionInformation.*;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +86,8 @@ public class AdminUserServiceImpl implements AdminUserService {
             throw new BaseException(PASSWORD_DIFFERENT);
         }
 
-        userMapper.updateLastLoggedAt(user.getId(), new Date());
+        user.updateLastLoginTimeToCurrent();
+        userMapper.updateUser(user);
 
         String accessToken = getAccessTokenFromRedis(user);
         if (isTokenNotExistOrExpired(accessToken)) {

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -206,14 +206,6 @@
         <result property="grant_event" column="owners.grant_event"/>
     </resultMap>
 
-    <update id="updateLastLoggedAt">
-        UPDATE `koin`.`users`
-        SET `last_logged_at` = #{currentDate}
-        WHERE
-            `id` = #{id}
-            AND `is_deleted` = 0
-    </update>
-
     <delete id="deleteUser" parameterType="koreatech.in.domain.User.User">
         DELETE
         FROM `koin`.`users`


### PR DESCRIPTION
- 잘못되어있던 Swagger 422 응답 타입 변경
- service 메소드 이름 변경 (`ForAdmin` 제거)
- 마지막 로그인 시간 업데이트 로직을 `User` 클래스의 메소드로 작성
- service에서 쓰지 않는 필드 제거