### PR TITLE
Task: 첨부파일 삭제 API

### DIFF
--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -163,14 +163,14 @@ public class OwnerController {
 
 
     @ApiResponses({
-            @ApiResponse(code = 401, message
-                    = "토큰에 대한 회원 정보가 없을 때 (code: 101000)"
+            @ApiResponse(code = 401
+                    , message = "- 토큰에 대한 회원 정보가 없을 때 (code: 101000)"
                     , response = ExceptionResponse.class),
             @ApiResponse(code = 403
                     , message = "- 권한이 없을 때 (code: 100003)"
                     , response = ExceptionResponse.class),
-            @ApiResponse(code = 404, message
-                    = "요청한 첨부파일이 존재하지 않을 때(code: 121003)"
+            @ApiResponse(code = 404
+                    , message = "- 요청한 첨부파일이 존재하지 않을 때(code: 121003)"
                     , response = ExceptionResponse.class),
             @ApiResponse(code = 422
                     , message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)"

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -166,10 +166,15 @@ public class OwnerController {
             @ApiResponse(code = 401, message
                     = "토큰에 대한 회원 정보가 없을 때 (code: 101000)"
                     , response = ExceptionResponse.class),
-            @ApiResponse(
-                    code = 422,
-                    message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)",
-                    response = RequestDataInvalidResponse.class)
+            @ApiResponse(code = 403
+                    , message = "- 권한이 없을 때 (code: 100003)"
+                    , response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message
+                    = "요청한 첨부파일이 존재하지 않을 때(code: 121003)"
+                    , response = ExceptionResponse.class),
+            @ApiResponse(code = 422
+                    , message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)"
+                    , response = RequestDataInvalidResponse.class)
     })
     @ApiOperation(value = "사장님 첨부파일 삭제", notes= "- 사장님 권한[+가게 권한 부여] 필요",
             authorizations = {@Authorization(value="Authorization")})
@@ -177,7 +182,7 @@ public class OwnerController {
     @ParamValid
     public @ResponseBody
     ResponseEntity<EmptyResponse> deleteAttachment(@ApiParam(required = true) @PathVariable("id") Integer attachmentId) {
-
+        ownerService.deleteAttachment(attachmentId);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -3,6 +3,7 @@ package koreatech.in.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
@@ -28,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -157,5 +159,25 @@ public class OwnerController {
     ResponseEntity<OwnerResponse> getOwner() {
         OwnerResponse owner = ownerService.getOwner();
         return new ResponseEntity<>(owner, HttpStatus.CREATED);
+    }
+
+
+    @ApiResponses({
+            @ApiResponse(code = 401, message
+                    = "토큰에 대한 회원 정보가 없을 때 (code: 101000)"
+                    , response = ExceptionResponse.class),
+            @ApiResponse(
+                    code = 422,
+                    message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)",
+                    response = RequestDataInvalidResponse.class)
+    })
+    @ApiOperation(value = "사장님 첨부파일 삭제", notes= "- 사장님 권한[+가게 권한 부여] 필요",
+            authorizations = {@Authorization(value="Authorization")})
+    @RequestMapping(value = "/owners/attachment/{id}", method = RequestMethod.DELETE)
+    @ParamValid
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> deleteAttachment(@ApiParam(required = true) @PathVariable("id") Integer attachmentId) {
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -1,7 +1,6 @@
 package koreatech.in.exception;
 
 import lombok.Getter;
-import org.hibernate.validator.constraints.URL;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -68,6 +67,7 @@ public enum ExceptionInformation {
     // ======= 사장님 =======
     CERTIFICATION_CODE_EXPIRED("코드 인증 기한이 경과되었습니다.", 121001, HttpStatus.GONE),
     CERTIFICATION_CODE_INVALID("인증 코드가 일치하지 않습니다.", 121002, HttpStatus.UNPROCESSABLE_ENTITY),
+    OWNER_ATTACHMENT_NOT_FOUND("존재하지 않는 첨부파일입니다.", 121003, HttpStatus.NOT_FOUND),
 
     // ======= BCSDLab 트랙 =======
     TRACK_NOT_FOUND("트랙이 존재하지 않습니다.", 201000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -17,6 +17,7 @@ public interface OwnerMapper {
     void deleteOwner(Integer id);
 
     OwnerAttachment getOwnerAttachmentById(Long id);
+    void deleteOwnerAttachmentLogically(Long id);
 
     void insertOwnerShopAttachment(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -1,6 +1,7 @@
 package koreatech.in.repository.user;
 
 import koreatech.in.domain.User.owner.Owner;
+import koreatech.in.domain.User.owner.OwnerAttachment;
 import koreatech.in.domain.User.owner.OwnerAttachments;
 import org.apache.ibatis.annotations.Update;
 import org.springframework.stereotype.Repository;
@@ -14,6 +15,8 @@ public interface OwnerMapper {
     void insertOwner(Owner owner);
     void safeDeleteOwner(Owner owner);
     void deleteOwner(Integer id);
+
+    OwnerAttachment getOwnerAttachmentById(Long id);
 
     void insertOwnerShopAttachment(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/service/OwnerService.java
+++ b/src/main/java/koreatech/in/service/OwnerService.java
@@ -14,4 +14,6 @@ public interface OwnerService {
     void register(OwnerRegisterRequest ownerRegisterRequest);
 
     OwnerResponse getOwner();
+
+    void deleteAttachment(Integer attachmentId);
 }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -121,6 +121,10 @@ public class OwnerServiceImpl implements OwnerService {
         return OwnerConverter.INSTANCE.toOwnerResponse(ownerInDB);
     }
 
+    @Override
+    public void deleteAttachment(Integer attachmentId) {
+    }
+
     private void validateEmailUniqueness(EmailAddress emailAddress) {
         if(userMapper.isEmailAlreadyExist(emailAddress).equals(true)) {
             throw new BaseException(ExceptionInformation.EMAIL_DUPLICATED);

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -11,6 +11,7 @@ import koreatech.in.domain.User.EmailAddress;
 import koreatech.in.domain.User.UserType;
 import koreatech.in.domain.User.owner.CertificationCode;
 import koreatech.in.domain.User.owner.Owner;
+import koreatech.in.domain.User.owner.OwnerAttachment;
 import koreatech.in.domain.User.owner.OwnerInCertification;
 import koreatech.in.domain.User.owner.OwnerInVerification;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
@@ -123,6 +124,21 @@ public class OwnerServiceImpl implements OwnerService {
 
     @Override
     public void deleteAttachment(Integer attachmentId) {
+        Integer userId = jwtValidator.validate().getId();
+
+        OwnerAttachment attachmentInDB = ownerMapper.getOwnerAttachmentById(attachmentId.longValue());
+
+        if(attachmentInDB == null) {
+            return;
+            // throw 첨부파일 낫 파운드
+        }
+
+        if(!attachmentInDB.getOwnerId().equals(userId)) {
+            return;
+//            throw new BaseException("소유자가 아닙니당")
+        }
+
+
     }
 
     private void validateEmailUniqueness(EmailAddress emailAddress) {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -125,20 +125,21 @@ public class OwnerServiceImpl implements OwnerService {
     @Override
     public void deleteAttachment(Integer attachmentId) {
         Integer userId = jwtValidator.validate().getId();
-
         OwnerAttachment attachmentInDB = ownerMapper.getOwnerAttachmentById(attachmentId.longValue());
 
+        validateInDelete(userId, attachmentInDB);
+
+        ownerMapper.deleteOwnerAttachmentLogically(attachmentId.longValue());
+    }
+
+    private static void validateInDelete(Integer userId, OwnerAttachment attachmentInDB) {
         if(attachmentInDB == null) {
-            return;
-            // throw 첨부파일 낫 파운드
+            throw new BaseException(ExceptionInformation.OWNER_ATTACHMENT_NOT_FOUND);
         }
 
         if(!attachmentInDB.getOwnerId().equals(userId)) {
-            return;
-//            throw new BaseException("소유자가 아닙니당")
+            throw new BaseException(ExceptionInformation.FORBIDDEN);
         }
-
-
     }
 
     private void validateEmailUniqueness(EmailAddress emailAddress) {

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -88,4 +88,10 @@
         WHERE id = #{id}
           AND is_deleted = FALSE
     </select>
+
+    <update id="deleteOwnerAttachmentLogically">
+        UPDATE koin.owner_shop_attachment
+        SET is_deleted = TRUE
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -26,6 +26,11 @@
         <result property="name" column="name"/>
     </resultMap>
 
+    <resultMap id="ownerAttachmentResultMap" type="koreatech.in.domain.User.owner.OwnerAttachment">
+        <id property="id" column="attachment_id"/>
+        <result property="ownerId" column="owner_id"/>
+    </resultMap>
+
     <select id="getOwnerById" resultMap="ownerShopsResultMap">
         SELECT users.id                           AS id,
                users.email                        AS email,
@@ -73,4 +78,14 @@
             )
         </foreach>
     </insert>
+
+
+    <select id="getOwnerAttachmentById" resultMap="ownerAttachmentResultMap">
+        SELECT id,
+               owner_id
+        FROM koin.owner_shop_attachment
+
+        WHERE id = #{id}
+          AND is_deleted = FALSE
+    </select>
 </mapper>


### PR DESCRIPTION
## Task: 첨부파일 삭제 API

**기능 변경사항**

- `DELETE /owners/attachment/{id}` API 생성

**코드 구현사항**

- Controller & Service에 `deleteAttachment` 메서드 추가
- Repository에  `deleteOwnerAttachmentLogically` 메서드 추가
- 첨부파일을 못 찾은 경우에 대한 예외 추가