### PR TITLE
Fix: `HH:MM` 형식이 아닐 경우 예외 대신 별도 응답을 반환하도록 수정

### DIFF
--- a/src/main/java/koreatech/in/service/BusServiceImpl.java
+++ b/src/main/java/koreatech/in/service/BusServiceImpl.java
@@ -29,6 +29,8 @@ public class BusServiceImpl implements BusService {
         try {
             Bus bus = BusTypeEnum.createBus(busType);
             return bus.getNowAndNextBusRemainTime(busType, depart, arrival);
+        }  catch (DateTimeParseException e) {
+            return new BusRemainTime(busType);
         } catch (IllegalArgumentException | NullPointerException e) {
             throw new PreconditionFailedException(new ErrorMessage("올바르지 않은 파라미터입니다.", 0));
         }


### PR DESCRIPTION
# Fix: `HH:MM` 형식이 아닐 경우 예외 대신 별도 응답을 반환하도록 수정

**기능 변경사항**
`HH:MM` 형식이 아닐 경우 예외 대신 ※별도 응답을 반환하도록 수정

**코드 구현사항**
`BusServiceImpl`, `getRemainTime` 에서 `DateTimeParseException`이 발생한 경우  ※별도 응답을 반환하도록 수정

**기타**
※별도 응답: 금일 현재 시간 이후 버스가 없음을 나타내는 응답
- [프론트 깃헙 코드 (링크)](https://github.com/BCSDLab/KOIN_WEB_RECODE/blob/10fdba864f09d0aac8412f2e8d6613130fd184bd/src/pages/BusPage/hooks/useBusLeftTime.ts) 에서 사용하는 형식을 차용함.

JSON: 
```
{
  now_bus: {
    remain_time: '미운행',
    bus_number: null,
  },
  next_bus: {
    remain_time: '미운행',
    bus_number: null,
  },
}
```