### PR TITLE
Refactor: UserMapper의 불필요한 메소드 제거

### DIFF
--- a/src/main/java/koreatech/in/repository/user/UserMapper.java
+++ b/src/main/java/koreatech/in/repository/user/UserMapper.java
@@ -1,15 +1,10 @@
 package koreatech.in.repository.user;
 
 import java.sql.SQLException;
-import java.util.Date;
 import java.util.List;
-import koreatech.in.domain.Authority;
 import koreatech.in.domain.User.EmailAddress;
 import koreatech.in.domain.User.User;
-import koreatech.in.domain.User.UserType;
-import koreatech.in.domain.User.Users;
 import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Select;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,25 +22,11 @@ public interface UserMapper {
     void deleteRelationBetweenOwnerAndShop(@Param("ownerId") Integer ownerId);
 
 
-//    Integer isAccountAlreadyUsed(String account);
-    Integer isNicknameAlreadyUsed(String nickname);
-    void updateUserIsAuthed(@Param("id")Integer id, @Param("isAuth")Boolean isAuth);
-    void updateResetTokenAndResetTokenExpiredTime(@Param("id") Integer id, @Param("resetToken") String resetToken, @Param("resetTokenExpiredTime") Date resetTokenExpiredTime);
+
 //    Users getUserListForAdmin(@Param("cursor") int cursor, @Param("limit") int limit);
     List<User> getUserListForAdmin(@Param("cursor") int cursor, @Param("limit") int limit, @Param("userType") String userType);
 
-    @Select("SELECT * FROM koin.admins WHERE USER_ID = #{id}")
-    Authority getAuthorityByUserIdForAdmin(@Param("id") int id);
     void insertUser(User user) throws SQLException;
-    User getUserById(@Param("id") int id);
-
-    UserType getUserTypeById(@Param("id") int id);
-    String getUserEmail(@Param("id") int id);
-    Integer getTotalCount();
-
-    // TODO: JOIN으로 처리할 수 있는지 알아보기.
-//    @Select("SELECT * FROM koin.users u INNER JOIN koin.admins a ON u.id = a.user_id WHERE u.id = #{id}")
-//    User findByUserWithAuthority(int id);
 
     Boolean isEmailAlreadyExist(EmailAddress emailAddress);
 }

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -134,12 +134,13 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Override
     public User getUserForAdmin(int id) {
-        User user = userMapper.getUserById(id);
+        /*User user = userMapper.getUserById(id);
 
         if(user == null){
             throw new NotFoundException(new ErrorMessage("User not found.", 0));
         }
-        return user;
+        return user;*/
+        return null;
     }
 
     @Override
@@ -155,9 +156,9 @@ public class AdminUserServiceImpl implements AdminUserService {
 
         // 닉네임 중복 체크
         if (student.getNickname() != null) {
-            if (userMapper.isNicknameAlreadyUsed(student.getNickname()) > 0){
+            /*if (userMapper.isNicknameAlreadyUsed(student.getNickname()) > 0){
                 throw new ConflictException(new ErrorMessage("nickname duplicate", 1));
-            }
+            }*/
         }
 
         // 학번 유효성 체크
@@ -200,7 +201,7 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Override
     public StudentResponse updateStudentForAdmin(UpdateUserRequest updateUserRequest, int id) {
-        User user =  userMapper.getUserById(id);
+        /*User user =  userMapper.getUserById(id);
         if (!user.isStudent()) {
             throw new NotFoundException(new ErrorMessage("User is not Student", 0));
         }
@@ -238,7 +239,8 @@ public class AdminUserServiceImpl implements AdminUserService {
         userMapper.updateUser(selectUser);
         studentMapper.updateStudent(selectUser);
 
-        return new StudentResponse(student);
+        return new StudentResponse(student);*/
+        return null;
     }
 
     @Override
@@ -268,7 +270,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     @Transactional
     @Override
     public Authority createPermissionForAdmin(Authority authority, int userId) {
-        User selectUser = userMapper.getUserById(userId);
+        /*User selectUser = userMapper.getUserById(userId);
         if(selectUser == null){
             throw new NotFoundException(new ErrorMessage("No User", 0));
         }
@@ -283,7 +285,8 @@ public class AdminUserServiceImpl implements AdminUserService {
 
         authorityMapper.createAuthority(authority);
 
-        return authority;
+        return authority;*/
+        return null;
     }
 
     @Override
@@ -328,7 +331,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     }
     @Override
     public Map<String, Object> getPermissionListForAdmin(int page, int limit) throws Exception {
-        Map<String, Object> map = new HashMap<>();
+        /*Map<String, Object> map = new HashMap<>();
 
         limit = Math.min(limit, 50);
         page = Math.max(page, 1);
@@ -361,7 +364,8 @@ public class AdminUserServiceImpl implements AdminUserService {
         map.put("admins", listedAdmin);
         map.put("totalPage", totalPage);
 
-        return map;
+        return map;*/
+        return null;
     }
 
     @Override

--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -585,78 +585,9 @@
         WHERE `owner_id` = #{ownerId}
     </update>
 
-    <select id="getUserById" parameterType="Integer" resultMap="UserDiscriminator">
-        SELECT
-            `t1`.`id` AS `users.id`,
-            `t1`.`email` AS `users.email`,
-            `t1`.`password` AS `users.password`,
-            `t1`.`nickname` AS `users.nickname`,
-            `t1`.`name` AS `users.name`,
-            `t1`.`phone_number` AS `users.phone_number`,
-            `t1`.`user_type` AS `users.user_type`,
-            `t1`.`gender` AS `users.gender`,
-            `t1`.`is_authed` AS `users.is_authed`,
-            `t1`.`last_logged_at` AS `users.last_logged_at`,
-            `t1`.`profile_image_url` AS `users.profile_image_url`,
-            `t1`.`auth_token` AS `users.auth_token`,
-            `t1`.`auth_expired_at` AS `users.auth_expired_at`,
-            `t1`.`reset_token` AS `users.reset_token`,
-            `t1`.`reset_expired_at` AS `users.reset_expired_at`,
-            `t1`.`is_deleted` AS `users.is_deleted`,
-            `t1`.`created_at` AS `users.created_at`,
-            `t1`.`updated_at` AS `users.updated_at`,
 
-            `t2`.`anonymous_nickname` AS `students.anonymous_nickname`,
-            `t2`.`student_number` AS `students.student_number`,
-            `t2`.`major` AS `students.major`,
-            `t2`.`identity` AS `students.identity`,
-            `t2`.`is_graduated` AS `students.is_graduated`,
-
-            `t3`.`company_registration_number` AS `owners.company_registration_number`,
-            `t3`.`grant_shop` AS `owners.grant_shop`,
-            `t3`.`grant_event` AS `owners.grant_event`,
-
-            `t4`.`id` AS `admins.id`,
-            `t4`.`user_id` AS `admins.user_id`,
-            `t4`.`grant_user` AS `admins.grant_user`,
-            `t4`.`grant_callvan` AS `admins.grant_callvan`,
-            `t4`.`grant_land` AS `admins.grant_land`,
-            `t4`.`grant_community` AS `admins.grant_community`,
-            `t4`.`grant_shop` AS `admins.grant_shop`,
-            `t4`.`grant_version` AS `admins.grant_version`,
-            `t4`.`grant_market` AS `admins.grant_market`,
-            `t4`.`grant_circle` AS `admins.grant_circle`,
-            `t4`.`grant_lost` AS `admins.grant_lost`,
-            `t4`.`grant_survey` AS `admins.grant_survey`,
-            `t4`.`grant_bcsdlab` AS `admins.grant_bcsdlab`,
-            `t4`.`grant_event` AS `admins.grant_event`,
-            `t4`.`is_deleted` AS `admins.is_deleted`,
-            `t4`.`created_at` AS `admins.created_at`,
-            `t4`.`updated_at` AS `admins.updated_at`
-
-        FROM (
-                 SELECT *
-                 FROM `koin`.`users`
-                 WHERE
-                     id = #{id}
-             ) `t1`
-
-                 LEFT JOIN `koin`.`students` `t2`
-                           ON `t1`.`id` = `t2`.`user_id`
-
-                 LEFT JOIN `koin`.`owners` `t3`
-                           ON `t1`.`id` = `t3`.`user_id`
-
-                 LEFT JOIN `koin`.`admins` `t4`
-                           ON
-                                       `t1`.`id` = `t4`.`user_id`
-                                   AND `t4`.`is_deleted` = 0
-    </select>
 <!--    UserResultMap 으로는 getUserById의 result 와 매핑이 안됨. (users.field) 꼴이기 떄문-->
 
-    <select id="getTotalCount" resultType="Integer">
-        SELECT COUNT(*) AS totalCount FROM koin.users WHERE IS_DELETED = 0;
-    </select>
 
     <select id="getUserListForAdmin" resultMap="UserResultMapV2">
         SELECT
@@ -761,12 +692,6 @@
 <!--                                   AND `t4`.`is_deleted` = 0-->
 <!--    </select>-->
 
-    <select id="isAccountAlreadyUsed" resultType="Integer">
-        select count(*)
-        from koin.users
-        where account=#{account} and is_deleted=0
-        limit 1;
-    </select>
 
 <!--    <select id="isAccountAlreadyUsed" resultType="Integer">-->
 <!--        select count(*)-->
@@ -775,26 +700,8 @@
 <!--        limit 1;-->
 <!--    </select>-->
 
-    <select id="isNicknameAlreadyUsed" resultType="Integer">
-        select count(*)
-        from koin.users
-        where nickname=#{nickname}
-          and is_deleted=0 limit 1;
-    </select>
 
-    <select id="getUserByNickName" resultMap="UserDiscriminator">
-        SELECT *
-        FROM koin.users
-        WHERE NICKNAME = #{nickname} AND IS_DELETED = 0;
-    </select>
 
-    <select id="getUserTypeById" resultType="koreatech.in.domain.User.UserType">
-        SELECT user_type as userType FROM koin.users WHERE ID = #{id}
-    </select>
-
-    <select id="getUserEmail" resultType="String">
-        SELECT EMAIL FROM koin.users WHERE ID = #{id}
-    </select>
 
     <insert id="insertUser" parameterType="koreatech.in.domain.User.User">
         INSERT INTO koin.users (
@@ -826,19 +733,8 @@
         </selectKey>
     </insert>
 
-    <update id="updateUserIsAuthed">
-        update koin.users
-        set is_authed=#{isAuth}
-        where id=#{id}
-    </update>
 
-    <update id="updateResetTokenAndResetTokenExpiredTime">
-        update koin.users
-        set
-            reset_token=#{resetToken},
-            reset_expired_at=#{resetTokenExpiredTime}
-        where id=#{id}
-    </update>
+
 
 
     <select id="isEmailAlreadyExist" parameterType="koreatech.in.domain.User.EmailAddress" resultType="Boolean">


### PR DESCRIPTION
- UserMapper.java에서 사용하지 않는 메소드와, 해당 메소드에 대응되는 xml 파일의 내용을 제거
- AdminUserServiceImpl.java에서 사용하고 있던 메소드의 경우 다음의 이유로 제거함
  - 쓰지 않는 API에서 호출하는 메소드
  - 쓰긴하지만 어드민 페이지 V2에서 개편될 API의 메소드 