### PR TITLE
Task: 학생 회원가입 API 메소드 이름 변경

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -109,7 +109,7 @@ public class UserController {
     @ApiOperation(value = "학생 회원가입", notes= "- 권한 필요 없음")
     @RequestMapping(value = "/user/student/register", method = RequestMethod.POST)
     public @ResponseBody
-    ResponseEntity<EmptyResponse> studentRegister(
+    ResponseEntity<EmptyResponse> registerStudent(
             @ApiParam(required = true) @RequestBody @Validated StudentRegisterRequest request,
             BindingResult bindingResult,
             HttpServletRequest httpServletRequest) {
@@ -123,7 +123,7 @@ public class UserController {
             throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
         }
 
-        userService.StudentRegister(request, getHost(httpServletRequest));
+        userService.registerStudent(request, getHost(httpServletRequest));
 
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -26,7 +26,7 @@ import koreatech.in.dto.normal.user.request.LoginRequest;
 import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
 import koreatech.in.dto.normal.user.response.LoginResponse;
-import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;
+import koreatech.in.dto.normal.user.student.request.RegisterStudentRequest;
 import koreatech.in.dto.normal.user.student.response.StudentResponse;
 import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ExceptionInformation;
@@ -110,7 +110,7 @@ public class UserController {
     @RequestMapping(value = "/user/student/register", method = RequestMethod.POST)
     public @ResponseBody
     ResponseEntity<EmptyResponse> registerStudent(
-            @ApiParam(required = true) @RequestBody @Validated StudentRegisterRequest request,
+            @ApiParam(required = true) @RequestBody @Validated RegisterStudentRequest request,
             BindingResult bindingResult,
             HttpServletRequest httpServletRequest) {
 

--- a/src/main/java/koreatech/in/dto/normal/user/student/request/RegisterStudentRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/student/request/RegisterStudentRequest.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-public class StudentRegisterRequest extends UserRegisterRequest {
+public class RegisterStudentRequest extends UserRegisterRequest {
 //
 //    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
 //    @ApiModelProperty(notes = "이름 \n"

--- a/src/main/java/koreatech/in/mapstruct/UserConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/UserConverter.java
@@ -10,7 +10,7 @@ import koreatech.in.dto.normal.user.request.AuthTokenRequest;
 import koreatech.in.dto.normal.user.request.CheckExistsEmailRequest;
 import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
-import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;
+import koreatech.in.dto.normal.user.student.request.RegisterStudentRequest;
 import koreatech.in.dto.normal.user.student.response.StudentResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -112,7 +112,7 @@ public interface UserConverter {
             @Mapping(source = "studentNumber", target = "studentNumber"),
             @Mapping(source = "phoneNumber", target = "phoneNumber"),
     })
-    Student toStudent(StudentRegisterRequest studentRegisterRequest);
+    Student toStudent(RegisterStudentRequest studentRegisterRequest);
 
     @Mapping(source = "token", target = "token")
     AuthToken toAuthToken(AuthTokenRequest token);

--- a/src/main/java/koreatech/in/service/UserService.java
+++ b/src/main/java/koreatech/in/service/UserService.java
@@ -17,7 +17,7 @@ public interface UserService {
 
     void logout();
 
-    void StudentRegister(StudentRegisterRequest request, String host);
+    void registerStudent(StudentRegisterRequest request, String host);
 
     StudentResponse getStudent();
 

--- a/src/main/java/koreatech/in/service/UserService.java
+++ b/src/main/java/koreatech/in/service/UserService.java
@@ -9,7 +9,7 @@ import koreatech.in.dto.normal.user.request.LoginRequest;
 import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
 import koreatech.in.dto.normal.user.response.LoginResponse;
-import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;
+import koreatech.in.dto.normal.user.student.request.RegisterStudentRequest;
 import koreatech.in.dto.normal.user.student.response.StudentResponse;
 
 public interface UserService {
@@ -17,7 +17,7 @@ public interface UserService {
 
     void logout();
 
-    void registerStudent(StudentRegisterRequest request, String host);
+    void registerStudent(RegisterStudentRequest request, String host);
 
     StudentResponse getStudent();
 

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -147,7 +147,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     @Override
-    public void StudentRegister(StudentRegisterRequest request, String host) {
+    public void registerStudent(StudentRegisterRequest request, String host) {
         Student student = UserConverter.INSTANCE.toStudent(request);
 
         validateInRegister(student);

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -23,7 +23,7 @@ import koreatech.in.dto.normal.user.request.LoginRequest;
 import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
 import koreatech.in.dto.normal.user.response.LoginResponse;
-import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;
+import koreatech.in.dto.normal.user.student.request.RegisterStudentRequest;
 import koreatech.in.dto.normal.user.student.response.StudentResponse;
 import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ConflictException;
@@ -147,7 +147,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     @Override
-    public void registerStudent(StudentRegisterRequest request, String host) {
+    public void registerStudent(RegisterStudentRequest request, String host) {
         Student student = UserConverter.INSTANCE.toStudent(request);
 
         validateInRegister(student);


### PR DESCRIPTION
- service, controller 메소드 이름 변경
  - `studentRegister` -> `registerStudent`
  - 동사가 앞에 나오는 자바 컨벤션에 맞게 정정

- dto 이름 변경
  - `StudentRegisterRequest` -> `RegisterStudentRequest`
  - dto 이름 생성시 `동사+엔티티이름+(Request or Response)`로 하던 방식에 맞게 변경