### PR TITLE
Feature: 사장님 업데이트 API

### DIFF
--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -204,7 +204,7 @@ public class OwnerController {
                     response = RequestDataInvalidResponse.class)
     })
     @ApiOperation(value = "사장님 정보 수정", notes = "- 사장님 권한[+가게 권한 부여] 필요")
-    @RequestMapping(value = "/owners", method = RequestMethod.PUT)
+    @RequestMapping(value = "/owner", method = RequestMethod.PUT)
     @ParamValid
     public @ResponseBody
     ResponseEntity<OwnerResponse> update(@RequestBody @Valid OwnerUpdateRequest request,

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -163,14 +163,14 @@ public class OwnerController {
 
 
     @ApiResponses({
-            @ApiResponse(code = 401, message
-                    = "토큰에 대한 회원 정보가 없을 때 (code: 101000)"
+            @ApiResponse(code = 401
+                    , message = "- 토큰에 대한 회원 정보가 없을 때 (code: 101000)"
                     , response = ExceptionResponse.class),
             @ApiResponse(code = 403
                     , message = "- 권한이 없을 때 (code: 100003)"
                     , response = ExceptionResponse.class),
-            @ApiResponse(code = 404, message
-                    = "요청한 첨부파일이 존재하지 않을 때(code: 121003)"
+            @ApiResponse(code = 404
+                    , message = "- 요청한 첨부파일이 존재하지 않을 때(code: 121003)"
                     , response = ExceptionResponse.class),
             @ApiResponse(code = 422
                     , message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)"

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -166,10 +166,15 @@ public class OwnerController {
             @ApiResponse(code = 401, message
                     = "토큰에 대한 회원 정보가 없을 때 (code: 101000)"
                     , response = ExceptionResponse.class),
-            @ApiResponse(
-                    code = 422,
-                    message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)",
-                    response = RequestDataInvalidResponse.class)
+            @ApiResponse(code = 403
+                    , message = "- 권한이 없을 때 (code: 100003)"
+                    , response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message
+                    = "요청한 첨부파일이 존재하지 않을 때(code: 121003)"
+                    , response = ExceptionResponse.class),
+            @ApiResponse(code = 422
+                    , message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)"
+                    , response = RequestDataInvalidResponse.class)
     })
     @ApiOperation(value = "사장님 첨부파일 삭제", notes= "- 사장님 권한[+가게 권한 부여] 필요",
             authorizations = {@Authorization(value="Authorization")})
@@ -177,7 +182,7 @@ public class OwnerController {
     @ParamValid
     public @ResponseBody
     ResponseEntity<EmptyResponse> deleteAttachment(@ApiParam(required = true) @PathVariable("id") Integer attachmentId) {
-
+        ownerService.deleteAttachment(attachmentId);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -189,15 +189,12 @@ public class OwnerController {
 
 
     @ApiResponses({
-            @ApiResponse(
-                    code = 409,
-                    message = "- 인증이 되지 않은 이메일일 경우 (code: 101012) \n\n"
-                            + "- 이미 누군가 사용중인 이메일일 경우 (code: 101013)",
-                    response = ExceptionResponse.class),
-            @ApiResponse(
-                    code = 410,
-                    message = "- 저장기간(`2시간`)이 만료된 이메일일 경우 (code: 101010) \n\n",
-                    response = ExceptionResponse.class),
+            @ApiResponse(code = 401
+                    , message = "- 토큰에 대한 회원 정보가 없을 때 (code: 101000)"
+                    , response = ExceptionResponse.class),
+            @ApiResponse(code = 403
+                    , message = "- 권한이 없을 때 (code: 100003)"
+                    , response = ExceptionResponse.class),
             @ApiResponse(
                     code = 422,
                     message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)",
@@ -214,7 +211,8 @@ public class OwnerController {
         } catch (Exception exception) {
             throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
         }
+        OwnerResponse ownerResponse = ownerService.update(request);
 
-        return new ResponseEntity<>(ownerService.update(request), HttpStatus.CREATED);
+        return new ResponseEntity<>(ownerResponse, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -215,8 +215,6 @@ public class OwnerController {
             throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
         }
 
-        ownerService.update(request);
-
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        return new ResponseEntity<>(ownerService.update(request), HttpStatus.CREATED);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -3,6 +3,7 @@ package koreatech.in.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
@@ -28,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -157,5 +159,25 @@ public class OwnerController {
     ResponseEntity<OwnerResponse> getOwner() {
         OwnerResponse owner = ownerService.getOwner();
         return new ResponseEntity<>(owner, HttpStatus.CREATED);
+    }
+
+
+    @ApiResponses({
+            @ApiResponse(code = 401, message
+                    = "토큰에 대한 회원 정보가 없을 때 (code: 101000)"
+                    , response = ExceptionResponse.class),
+            @ApiResponse(
+                    code = 422,
+                    message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)",
+                    response = RequestDataInvalidResponse.class)
+    })
+    @ApiOperation(value = "사장님 첨부파일 삭제", notes= "- 사장님 권한[+가게 권한 부여] 필요",
+            authorizations = {@Authorization(value="Authorization")})
+    @RequestMapping(value = "/owners/attachment/{id}", method = RequestMethod.DELETE)
+    @ParamValid
+    public @ResponseBody
+    ResponseEntity<EmptyResponse> deleteAttachment(@ApiParam(required = true) @PathVariable("id") Integer attachmentId) {
+
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -17,6 +17,7 @@ import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
 import koreatech.in.dto.RequestDataInvalidResponse;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
+import koreatech.in.dto.normal.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyEmailRequest;
 import koreatech.in.dto.normal.user.owner.response.OwnerResponse;
@@ -183,6 +184,39 @@ public class OwnerController {
     public @ResponseBody
     ResponseEntity<EmptyResponse> deleteAttachment(@ApiParam(required = true) @PathVariable("id") Integer attachmentId) {
         ownerService.deleteAttachment(attachmentId);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+
+    @ApiResponses({
+            @ApiResponse(
+                    code = 409,
+                    message = "- 인증이 되지 않은 이메일일 경우 (code: 101012) \n\n"
+                            + "- 이미 누군가 사용중인 이메일일 경우 (code: 101013)",
+                    response = ExceptionResponse.class),
+            @ApiResponse(
+                    code = 410,
+                    message = "- 저장기간(`2시간`)이 만료된 이메일일 경우 (code: 101010) \n\n",
+                    response = ExceptionResponse.class),
+            @ApiResponse(
+                    code = 422,
+                    message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)",
+                    response = RequestDataInvalidResponse.class)
+    })
+    @ApiOperation(value = "사장님 정보 수정", notes = "- 사장님 권한[+가게 권한 부여] 필요")
+    @RequestMapping(value = "/owners", method = RequestMethod.PUT)
+    @ParamValid
+    public @ResponseBody
+    ResponseEntity<OwnerResponse> update(@RequestBody @Valid OwnerUpdateRequest request,
+                                           BindingResult bindingResult) {
+        try {
+            request = StringXssChecker.xssCheck(request, request.getClass().newInstance());
+        } catch (Exception exception) {
+            throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
+        }
+
+        ownerService.update(request);
+
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 }

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -23,7 +23,7 @@ import koreatech.in.dto.normal.user.request.AuthTokenRequest;
 import koreatech.in.dto.normal.user.request.CheckExistsEmailRequest;
 import koreatech.in.dto.normal.user.request.FindPasswordRequest;
 import koreatech.in.dto.normal.user.request.LoginRequest;
-import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
+import koreatech.in.dto.normal.user.student.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
 import koreatech.in.dto.normal.user.response.LoginResponse;
 import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;

--- a/src/main/java/koreatech/in/domain/User/owner/Owner.java
+++ b/src/main/java/koreatech/in/domain/User/owner/Owner.java
@@ -3,6 +3,7 @@ package koreatech.in.domain.User.owner;
 import java.util.List;
 import koreatech.in.domain.Shop.Shop;
 import koreatech.in.domain.User.User;
+import koreatech.in.domain.User.UserType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -33,5 +34,10 @@ public class Owner extends User {
         if (owner.email != null) {
             this.email = owner.email;
         }
+    }
+
+    public void enrichAuthComplete() {
+        setUser_type(UserType.OWNER);
+        setIs_authed(false);
     }
 }

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
@@ -3,7 +3,6 @@ package koreatech.in.domain.User.owner;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,10 +21,18 @@ public class OwnerAttachments {
         return new OwnerAttachments(attachments);
     }
 
-    public Set<String> getExistAttachmentUrls() {
+    public boolean isEmpty() {
+        return attachments.isEmpty();
+    }
+
+    // this 와 other 의 차집합을 반환
+    public OwnerAttachments removeDuplicatesFrom(OwnerAttachments other) {
         validateNonNullList(getAttachments());
 
-        return new HashSet<>(getAttachmentUrls());
+        Set<String> otherAttachments = other.makeAttachments();
+        List<OwnerAttachment> attachmentsRemovedDuplicates = removeDuplicates(otherAttachments);
+
+        return OwnerAttachments.from(attachmentsRemovedDuplicates);
     }
 
     private static void validateNonNullList(List<OwnerAttachment> attachments) {
@@ -34,32 +41,23 @@ public class OwnerAttachments {
         }
     }
 
+    private Set<String> makeAttachments() {
+        validateNonNullList(getAttachments());
+
+        return new HashSet<>(getAttachmentUrls());
+    }
+
     private List<String> getAttachmentUrls() {
         return getAttachments()
                 .stream()
                 .map(OwnerAttachment::getFileUrl)
                 .collect(Collectors.toList());
     }
-    
-    public OwnerAttachments selectToAdd(Set<String> existAttachmentUrls) {
-        return OwnerAttachments.from(filteredAttachmentsBy(
-                ownerAttachment -> !existAttachmentUrls.contains(ownerAttachment.getFileUrl()))
-        );
-    }
 
-
-    public OwnerAttachments selectToDelete(Set<String> existAttachmentUrls) {
-        return OwnerAttachments.from(filteredAttachmentsBy(
-                ownerAttachment -> existAttachmentUrls.contains(ownerAttachment.getFileUrl())
-        ));
-    }
-
-    private List<OwnerAttachment> filteredAttachmentsBy(Predicate<OwnerAttachment> filterPredicate) {
-        validateNonNullList(getAttachments());
-
+    private List<OwnerAttachment> removeDuplicates(Set<String> otherAttachments) {
         return getAttachments()
                 .stream()
-                .filter(filterPredicate)
+                .filter(ownerAttachment -> !otherAttachments.contains(ownerAttachment.getFileUrl()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
@@ -1,11 +1,63 @@
 package koreatech.in.domain.User.owner;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor @AllArgsConstructor
 public class OwnerAttachments {
     private List<OwnerAttachment> attachments;
+
+    public static OwnerAttachments from(List<OwnerAttachment> attachments) {
+        return new OwnerAttachments(attachments);
+    }
+
+    public Set<String> getExistAttachmentUrls() {
+        validateNonNullList();
+
+        return new HashSet<>(getAttachmentUrls());
+    }
+
+    private void validateNonNullList() {
+        if(getAttachments() == null) {
+            throw new RuntimeException("DB에 존재하는 사장님의 첨부파일은 비어있을 수 없습니다.");
+        }
+    }
+
+    private List<String> getAttachmentUrls() {
+        return getAttachments()
+                .stream()
+                .map(OwnerAttachment::getFileUrl)
+                .collect(Collectors.toList());
+    }
+    
+    public OwnerAttachments selectToAdd(Set<String> existAttachmentUrls) {
+        return OwnerAttachments.from(filteredAttachmentsBy(
+                ownerAttachment -> !existAttachmentUrls.contains(ownerAttachment.getFileUrl()))
+        );
+    }
+
+
+    public OwnerAttachments selectToDelete(Set<String> existAttachmentUrls) {
+        return OwnerAttachments.from(filteredAttachmentsBy(
+                ownerAttachment -> existAttachmentUrls.contains(ownerAttachment.getFileUrl())
+        ));
+    }
+
+    private List<OwnerAttachment> filteredAttachmentsBy(Predicate<OwnerAttachment> filterPredicate) {
+        validateNonNullList();
+
+        return getAttachments()
+                .stream()
+                .filter(filterPredicate)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
@@ -34,6 +34,15 @@ public class OwnerAttachments {
 
         return OwnerAttachments.from(attachmentsRemovedDuplicates);
     }
+    public void addAllFrom(OwnerAttachments ownerAttachments) {
+        attachments.addAll(ownerAttachments.getAttachments());
+    }
+
+    public OwnerAttachments intersectionWith(OwnerAttachments other) {
+        OwnerAttachments removedOtherDuplicates = removeDuplicatesFrom(other);
+
+        return removeDuplicatesFrom(removedOtherDuplicates);
+    }
 
     private static void validateNonNullList(List<OwnerAttachment> attachments) {
         if(attachments == null) {

--- a/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
+++ b/src/main/java/koreatech/in/domain/User/owner/OwnerAttachments.java
@@ -17,17 +17,19 @@ public class OwnerAttachments {
     private List<OwnerAttachment> attachments;
 
     public static OwnerAttachments from(List<OwnerAttachment> attachments) {
+        validateNonNullList(attachments);
+
         return new OwnerAttachments(attachments);
     }
 
     public Set<String> getExistAttachmentUrls() {
-        validateNonNullList();
+        validateNonNullList(getAttachments());
 
         return new HashSet<>(getAttachmentUrls());
     }
 
-    private void validateNonNullList() {
-        if(getAttachments() == null) {
+    private static void validateNonNullList(List<OwnerAttachment> attachments) {
+        if(attachments == null) {
             throw new RuntimeException("DB에 존재하는 사장님의 첨부파일은 비어있을 수 없습니다.");
         }
     }
@@ -53,7 +55,7 @@ public class OwnerAttachments {
     }
 
     private List<OwnerAttachment> filteredAttachmentsBy(Predicate<OwnerAttachment> filterPredicate) {
-        validateNonNullList();
+        validateNonNullList(getAttachments());
 
         return getAttachments()
                 .stream()

--- a/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
+++ b/src/main/java/koreatech/in/dto/global/AttachmentUrlRequest.java
@@ -12,7 +12,7 @@ import org.hibernate.validator.constraints.URL;
 @Setter
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class AttachmentUrlRequest {
-//    public static final String STATIC_KOREATECH_IN = "static.koreatech.in";
+
     @NotBlank
     @URL(protocol = "https", regexp = ".*static\\.koreatech\\.in.*"
             , message = "코인 파일 저장 형식이 아닙니다.")

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerUpdateRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerUpdateRequest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import koreatech.in.dto.global.AttachmentUrlRequest;
 import lombok.Getter;
@@ -18,14 +17,12 @@ import lombok.Setter;
 public class OwnerUpdateRequest // extends UserUpdateRequest // 사장님 Update에 대한 요청이 정확히 확인되지 않아, 필수적인 첨부파일만 넘기도록 함.
 {
 
-    @NotNull(message = "이미지 첨부는 필수입니다.")
     @Size(min = 3, max = 5, message = "이미지는 사업자등록증, 영업신고증, 통장사본을 포함하여 최소 3개 최대 5개까지 가능합니다.")
     @ApiModelProperty(notes = "첨부 이미지들 \n"
             + "- not null \n"
             + "- 이미지는 최소 3개 최대 5개까지 허용됨 \n"
             + "- 모든 이미지들이 코인 이미지 형식이어야 함 \n"
             , dataType = "[Lkoreatech.in.dto.global.AttachmentUrlRequest;"
-            , required = true
     )
     @Valid
     private List<AttachmentUrlRequest> attachmentUrls;

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerUpdateRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/OwnerUpdateRequest.java
@@ -1,0 +1,32 @@
+package koreatech.in.dto.normal.user.owner.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import koreatech.in.dto.global.AttachmentUrlRequest;
+import lombok.Getter;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class OwnerUpdateRequest // extends UserUpdateRequest // 사장님 Update에 대한 요청이 정확히 확인되지 않아, 필수적인 첨부파일만 넘기도록 함.
+{
+
+    @NotNull(message = "이미지 첨부는 필수입니다.")
+    @Size(min = 3, max = 5, message = "이미지는 사업자등록증, 영업신고증, 통장사본을 포함하여 최소 3개 최대 5개까지 가능합니다.")
+    @ApiModelProperty(notes = "첨부 이미지들 \n"
+            + "- not null \n"
+            + "- 이미지는 최소 3개 최대 5개까지 허용됨 \n"
+            + "- 모든 이미지들이 코인 이미지 형식이어야 함 \n"
+            , dataType = "[Lkoreatech.in.dto.global.AttachmentUrlRequest;"
+            , required = true
+    )
+    @Valid
+    private List<AttachmentUrlRequest> attachmentUrls;
+}

--- a/src/main/java/koreatech/in/dto/normal/user/owner/response/OwnerResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/response/OwnerResponse.java
@@ -18,7 +18,6 @@ import lombok.experimental.SuperBuilder;
 public class OwnerResponse extends UserResponse {
 
     @ApiModelProperty(notes = "이름 \n"
-            + "50자 이내여야 함"
             , example = "정보혁"
             , required = true
     )

--- a/src/main/java/koreatech/in/dto/normal/user/request/UserUpdateRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/request/UserUpdateRequest.java
@@ -16,5 +16,7 @@ public class UserUpdateRequest {
     @ApiModelProperty(notes = "비밀번호", example = "a0240120305812krlakdsflsa;1235")
     private String password;
 
+
+    @ApiModelProperty(notes = "이름 \n", example = "정보혁")
     private String name;
 }

--- a/src/main/java/koreatech/in/dto/normal/user/response/UserResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/user/response/UserResponse.java
@@ -16,15 +16,12 @@ import lombok.experimental.SuperBuilder;
 public class UserResponse {
 
     @ApiModelProperty(notes = "이메일 주소 \n"
-            + "- not null \n"
-            + "- 이메일 형식이어야 함"
             , required = true
             , example = "koin123@koreatech.ac.kr"
     )
     private String email;
 
     @ApiModelProperty(notes = "이름 \n"
-            + "50자 이내여야 함"
             , example = "정보혁"
     )
     private String name;

--- a/src/main/java/koreatech/in/dto/normal/user/student/request/StudentUpdateRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/student/request/StudentUpdateRequest.java
@@ -1,10 +1,11 @@
-package koreatech.in.dto.normal.user.request;
+package koreatech.in.dto.normal.user.student.request;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import koreatech.in.dto.normal.user.request.UserUpdateRequest;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,7 +14,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-public class StudentUpdateRequest extends UserUpdateRequest{
+public class StudentUpdateRequest extends UserUpdateRequest {
 
     @Size(max = 10, message = "닉네임은 10자 이내여야 합니다.")
     @ApiModelProperty(notes = "닉네임", example = "bbo")

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -1,7 +1,6 @@
 package koreatech.in.exception;
 
 import lombok.Getter;
-import org.hibernate.validator.constraints.URL;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -68,6 +67,7 @@ public enum ExceptionInformation {
     // ======= 사장님 =======
     CERTIFICATION_CODE_EXPIRED("코드 인증 기한이 경과되었습니다.", 121001, HttpStatus.GONE),
     CERTIFICATION_CODE_INVALID("인증 코드가 일치하지 않습니다.", 121002, HttpStatus.UNPROCESSABLE_ENTITY),
+    OWNER_ATTACHMENT_NOT_FOUND("존재하지 않는 첨부파일입니다.", 121003, HttpStatus.NOT_FOUND),
 
     // ======= BCSDLab 트랙 =======
     TRACK_NOT_FOUND("트랙이 존재하지 않습니다.", 201000, HttpStatus.NOT_FOUND),

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -12,6 +12,7 @@ import koreatech.in.domain.User.owner.OwnerAttachment;
 import koreatech.in.domain.User.owner.OwnerAttachments;
 import koreatech.in.dto.global.AttachmentUrlRequest;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
+import koreatech.in.dto.normal.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyEmailRequest;
 import koreatech.in.dto.normal.user.owner.response.OwnerResponse;
@@ -64,8 +65,8 @@ public interface OwnerConverter {
     Owner toOwner(OwnerRegisterRequest ownerRegisterRequest);
 
     @Named("convertAttachments")
-    default List<OwnerAttachment> convertAttachments(List<AttachmentUrlRequest> companyCertificateAttachmentUrls) {
-        return companyCertificateAttachmentUrls.stream().map(
+    default List<OwnerAttachment> convertAttachments(List<AttachmentUrlRequest> attachmentUrls) {
+        return attachmentUrls.stream().map(
                         attachmentUrlRequest -> OwnerAttachment.builder().fileUrl(attachmentUrlRequest.getFileUrl()).build()
                 )
                 .collect(Collectors.toList());
@@ -88,13 +89,13 @@ public interface OwnerConverter {
             @Mapping(source = "email", target = "email"),
 
             @Mapping(source = "company_registration_number", target = "companyNumber"),
-            @Mapping(source = "attachments", target = "attachments", qualifiedByName = "convertAttachments"),
+            @Mapping(source = "attachments", target = "attachments", qualifiedByName = "convertAttachmentsForResponse"),
 
             @Mapping(source = "shops", target = "shops", qualifiedByName = "convertShops"),
     })
     OwnerResponse toOwnerResponse(Owner owner);
 
-    @Named("convertAttachments")
+    @Named("convertAttachmentsForResponse")
     default List<OwnerResponse.Attachment> convertAttachmentsForResponse(List<OwnerAttachment> attachments) {
         return attachments.stream().map(attachment ->
                 OwnerResponse.Attachment
@@ -113,4 +114,9 @@ public interface OwnerConverter {
                 .name(shop.getName())
                 .build()).collect(Collectors.toList());
     }
+
+    @Mappings({
+            @Mapping(source = "attachmentUrls", target = "attachments", qualifiedByName = "convertAttachments"),
+    })
+    Owner toOwner(OwnerUpdateRequest ownerUpdateRequest);
 }

--- a/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/OwnerConverter.java
@@ -73,12 +73,12 @@ public interface OwnerConverter {
     }
 
     @Mappings({
-            @Mapping(source = ".", target = "attachments", qualifiedByName = "convertAttachment")
+            @Mapping(source = ".", target = "attachments", qualifiedByName = "convertAttachments")
     })
-    OwnerAttachments toOwnerShopAttachments(Owner owner);
+    OwnerAttachments toOwnerAttachments(Owner owner);
 
-    @Named("convertAttachment")
-    default List<OwnerAttachment> convertAttachment(Owner owner) {
+    @Named("convertAttachments")
+    default List<OwnerAttachment> convertAttachments(Owner owner) {
         return owner.getAttachments().stream()
                 .map(attachment -> OwnerAttachment.builder().ownerId(owner.getId()).fileUrl(attachment.getFileUrl()).build())
                 .collect(Collectors.toList());

--- a/src/main/java/koreatech/in/mapstruct/UserConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/UserConverter.java
@@ -8,7 +8,7 @@ import koreatech.in.domain.User.LocalParts;
 import koreatech.in.domain.User.student.Student;
 import koreatech.in.dto.normal.user.request.AuthTokenRequest;
 import koreatech.in.dto.normal.user.request.CheckExistsEmailRequest;
-import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
+import koreatech.in.dto.normal.user.student.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
 import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;
 import koreatech.in.dto.normal.user.student.response.StudentResponse;

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -24,7 +24,9 @@ public interface OwnerMapper {
 
     void deleteOwnerAttachmentLogically(Long id);
 
-    void insertOwnerAttachments(OwnerAttachments ownerAttachments);
+    void insertOwnerAttachments(OwnerAttachments attachments);
+
+    void insertOwnerAttachment(OwnerAttachment attachment);
 
     void deleteOwnerAttachmentsLogically(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -17,6 +17,7 @@ public interface OwnerMapper {
     void deleteOwner(Integer id);
 
     OwnerAttachment getOwnerAttachmentById(Long id);
+    void deleteOwnerAttachmentLogically(Long id);
 
     void insertOwnerShopAttachment(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -20,5 +20,5 @@ public interface OwnerMapper {
     void deleteOwnerAttachmentLogically(Long id);
 
     void insertOwnerAttachments(OwnerAttachments ownerAttachments);
-    void deleteOwnerAttachmentLogically(OwnerAttachments ownerAttachments);
+    void deleteOwnerAttachmentsLogically(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -8,17 +8,23 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OwnerMapper {
-//    @Select("SELECT * FROM koin.users AS user LEFT JOIN koin.users_owners AS owner ON owner.user_id = user.id WHERE user.id = #{id}")
+    //    @Select("SELECT * FROM koin.users AS user LEFT JOIN koin.users_owners AS owner ON owner.user_id = user.id WHERE user.id = #{id}")
     Owner getOwnerById(Long id);
+
     @Update("UPDATE koin.users_owners AS owner SET owner.email = #{email} WHERE owner.user_id = #{id}")
     void updateOwner(Owner owner);
+
     void insertOwner(Owner owner);
+
     void safeDeleteOwner(Owner owner);
+
     void deleteOwner(Integer id);
 
     OwnerAttachment getOwnerAttachmentById(Long id);
+
     void deleteOwnerAttachmentLogically(Long id);
 
     void insertOwnerAttachments(OwnerAttachments ownerAttachments);
+
     void deleteOwnerAttachmentsLogically(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -26,6 +26,7 @@ public interface OwnerMapper {
 
     void insertOwnerAttachments(OwnerAttachments attachments);
 
+    //insertOwnerAttachments-foreach 에서, useGeneratedKeys 를 사용해도 id들을 채워주지 않아 반복문을 통해 OwnerAttachment 각각을 insert 함.
     void insertOwnerAttachment(OwnerAttachment attachment);
 
     void deleteOwnerAttachmentsLogically(OwnerAttachments ownerAttachments);

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -1,6 +1,7 @@
 package koreatech.in.repository.user;
 
 import koreatech.in.domain.User.owner.Owner;
+import koreatech.in.domain.User.owner.OwnerAttachment;
 import koreatech.in.domain.User.owner.OwnerAttachments;
 import org.apache.ibatis.annotations.Update;
 import org.springframework.stereotype.Repository;
@@ -14,6 +15,8 @@ public interface OwnerMapper {
     void insertOwner(Owner owner);
     void safeDeleteOwner(Owner owner);
     void deleteOwner(Integer id);
+
+    OwnerAttachment getOwnerAttachmentById(Long id);
 
     void insertOwnerShopAttachment(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -19,5 +19,6 @@ public interface OwnerMapper {
     OwnerAttachment getOwnerAttachmentById(Long id);
     void deleteOwnerAttachmentLogically(Long id);
 
-    void insertOwnerShopAttachment(OwnerAttachments ownerAttachments);
+    void insertOwnerAttachments(OwnerAttachments ownerAttachments);
+    void deleteOwnerAttachmentLogically(OwnerAttachments ownerAttachments);
 }

--- a/src/main/java/koreatech/in/service/JwtValidator.java
+++ b/src/main/java/koreatech/in/service/JwtValidator.java
@@ -1,5 +1,6 @@
 package koreatech.in.service;
 
+import javax.servlet.http.HttpServletRequest;
 import koreatech.in.domain.User.User;
 import koreatech.in.repository.user.UserMapper;
 import koreatech.in.util.JwtTokenGenerator;
@@ -7,8 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-
-import javax.servlet.http.HttpServletRequest;
 
 
 @Service
@@ -27,6 +26,16 @@ public class JwtValidator {
     }
 
     public User validate(String header) {
+        Integer userId = getUserId(header);
+        if (userId == null) {
+            return null;
+        }
+        User user = userMapper.getAuthedUserById(userId);
+
+        return user;
+    }
+
+    private Integer getUserId(String header) {
         if (header == null || !header.startsWith("Bearer ")) {
             return null;
         }
@@ -37,8 +46,12 @@ public class JwtValidator {
         }
 
         Integer userId = jwtTokenGenerator.me(accessToken);
-        User user = userMapper.getAuthedUserById(userId);
+        return userId;
+    }
 
-        return user;
+    public Integer validateAndGetUserId() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        return getUserId(request.getHeader("Authorization"));
     }
 }

--- a/src/main/java/koreatech/in/service/JwtValidator.java
+++ b/src/main/java/koreatech/in/service/JwtValidator.java
@@ -30,9 +30,8 @@ public class JwtValidator {
         if (userId == null) {
             return null;
         }
-        User user = userMapper.getAuthedUserById(userId);
 
-        return user;
+        return userMapper.getAuthedUserById(userId);
     }
 
     private Integer getUserId(String header) {
@@ -45,8 +44,7 @@ public class JwtValidator {
             return null;
         }
 
-        Integer userId = jwtTokenGenerator.me(accessToken);
-        return userId;
+        return jwtTokenGenerator.me(accessToken);
     }
 
     public Integer validateAndGetUserId() {

--- a/src/main/java/koreatech/in/service/OwnerService.java
+++ b/src/main/java/koreatech/in/service/OwnerService.java
@@ -18,5 +18,5 @@ public interface OwnerService {
 
     void deleteAttachment(Integer attachmentId);
 
-    void update(OwnerUpdateRequest ownerUpdateRequest);
+    OwnerResponse update(OwnerUpdateRequest ownerUpdateRequest);
 }

--- a/src/main/java/koreatech/in/service/OwnerService.java
+++ b/src/main/java/koreatech/in/service/OwnerService.java
@@ -14,4 +14,6 @@ public interface OwnerService {
     void register(OwnerRegisterRequest ownerRegisterRequest);
 
     OwnerResponse getOwner();
+
+    void deleteAttachment(Integer attachmentId);
 }

--- a/src/main/java/koreatech/in/service/OwnerService.java
+++ b/src/main/java/koreatech/in/service/OwnerService.java
@@ -1,6 +1,7 @@
 package koreatech.in.service;
 
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
+import koreatech.in.dto.normal.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyEmailRequest;
 import koreatech.in.dto.normal.user.owner.response.OwnerResponse;
@@ -16,4 +17,6 @@ public interface OwnerService {
     OwnerResponse getOwner();
 
     void deleteAttachment(Integer attachmentId);
+
+    void update(OwnerUpdateRequest ownerUpdateRequest);
 }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import koreatech.in.domain.User.EmailAddress;
-import koreatech.in.domain.User.UserType;
 import koreatech.in.domain.User.owner.CertificationCode;
 import koreatech.in.domain.User.owner.Owner;
 import koreatech.in.domain.User.owner.OwnerAttachment;
@@ -243,13 +242,8 @@ public class OwnerServiceImpl implements OwnerService {
         owner.setPassword(passwordEncoder.encode(owner.getPassword()));
     }
 
-    private static void enrichAuthComplete(Owner owner) {
-        owner.setUser_type(UserType.OWNER);
-        owner.setIs_authed(false);
-    }
-
     private void createInDBFor(Owner owner) {
-        enrichAuthComplete(owner);
+        owner.enrichAuthComplete();
 
         try {
             insertUserAndUpdateId(owner);

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -121,6 +121,10 @@ public class OwnerServiceImpl implements OwnerService {
         return OwnerConverter.INSTANCE.toOwnerResponse(ownerInDB);
     }
 
+    @Override
+    public void deleteAttachment(Integer attachmentId) {
+    }
+
     private void validateEmailUniqueness(EmailAddress emailAddress) {
         if(userMapper.isEmailAlreadyExist(emailAddress).equals(true)) {
             throw new BaseException(ExceptionInformation.EMAIL_DUPLICATED);

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -140,7 +140,8 @@ public class OwnerServiceImpl implements OwnerService {
         Owner owner = OwnerConverter.INSTANCE.toOwner(ownerUpdateRequest);
         Owner ownerInToken = getOwnerInToken();
 
-        updateAttachment(owner, ownerInToken);
+        OwnerAttachments ownerAttachments = OwnerConverter.INSTANCE.toOwnerAttachments(owner);
+        updateAttachment(ownerAttachments, ownerInToken);
         //생성은 가능, 삭제는 ??;
         //필드가 아에 비었을 수도 있짢아~
         return OwnerConverter.INSTANCE.toOwnerResponse(ownerInToken);
@@ -157,9 +158,8 @@ public class OwnerServiceImpl implements OwnerService {
 //        return UserConverter.INSTANCE.toStudentResponse(studentInToken);
     }
 
-    private static void updateAttachment(Owner owner, Owner ownerInToken) {
+    private static void updateAttachment(OwnerAttachments ownerAttachments, Owner ownerInToken) {
         //PK를 url로? // 중복이 생김 // 중복 체크 ? // 사장님 ID까지 PK로 넣기?
-        OwnerAttachments ownerAttachments = OwnerAttachments.from(owner.getAttachments());
         Set<String> existAttachmentUrls = OwnerAttachments.from(ownerInToken.getAttachments()).getExistAttachmentUrls();
 
         OwnerAttachments toAdd = ownerAttachments.selectToAdd(existAttachmentUrls);

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -137,14 +137,18 @@ public class OwnerServiceImpl implements OwnerService {
     @Override
     public OwnerResponse update(OwnerUpdateRequest ownerUpdateRequest) {
         Owner owner = OwnerConverter.INSTANCE.toOwner(ownerUpdateRequest);
-        Owner ownerInDB = getOwnerInToken();
+        Owner ownerInToken = getOwnerInToken();
 
+        updateDBFor(owner, ownerInToken);
+
+        return OwnerConverter.INSTANCE.toOwnerResponse(ownerInToken);
+    }
+
+    private void updateDBFor(Owner owner, Owner ownerInToken) {
         OwnerAttachments ownerAttachments = ownerAttachmentsFillWithOwnerId(owner);
-        OwnerAttachments ownerAttachmentsInDB = OwnerAttachments.from(ownerInDB.getAttachments());
+        OwnerAttachments ownerAttachmentsInDB = OwnerAttachments.from(ownerInToken.getAttachments());
 
         updateAttachment(ownerAttachments, ownerAttachmentsInDB);
-
-        return OwnerConverter.INSTANCE.toOwnerResponse(ownerInDB);
     }
 
     private static OwnerAttachments ownerAttachmentsFillWithOwnerId(Owner owner) {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -15,6 +15,7 @@ import koreatech.in.domain.User.owner.OwnerAttachment;
 import koreatech.in.domain.User.owner.OwnerInCertification;
 import koreatech.in.domain.User.owner.OwnerInVerification;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
+import koreatech.in.dto.normal.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyCodeRequest;
 import koreatech.in.dto.normal.user.owner.request.VerifyEmailRequest;
 import koreatech.in.dto.normal.user.owner.response.OwnerResponse;
@@ -130,6 +131,11 @@ public class OwnerServiceImpl implements OwnerService {
         validateInDelete(userId, attachmentInDB);
 
         ownerMapper.deleteOwnerAttachmentLogically(attachmentId.longValue());
+    }
+
+    @Override
+    public void update(OwnerUpdateRequest ownerUpdateRequest) {
+        jwtValidator.validate();
     }
 
     private static void validateInDelete(Integer userId, OwnerAttachment attachmentInDB) {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -11,6 +11,7 @@ import koreatech.in.domain.User.EmailAddress;
 import koreatech.in.domain.User.UserType;
 import koreatech.in.domain.User.owner.CertificationCode;
 import koreatech.in.domain.User.owner.Owner;
+import koreatech.in.domain.User.owner.OwnerAttachment;
 import koreatech.in.domain.User.owner.OwnerInCertification;
 import koreatech.in.domain.User.owner.OwnerInVerification;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
@@ -123,6 +124,21 @@ public class OwnerServiceImpl implements OwnerService {
 
     @Override
     public void deleteAttachment(Integer attachmentId) {
+        Integer userId = jwtValidator.validate().getId();
+
+        OwnerAttachment attachmentInDB = ownerMapper.getOwnerAttachmentById(attachmentId.longValue());
+
+        if(attachmentInDB == null) {
+            return;
+            // throw 첨부파일 낫 파운드
+        }
+
+        if(!attachmentInDB.getOwnerId().equals(userId)) {
+            return;
+//            throw new BaseException("소유자가 아닙니당")
+        }
+
+
     }
 
     private void validateEmailUniqueness(EmailAddress emailAddress) {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -257,7 +257,7 @@ public class OwnerServiceImpl implements OwnerService {
             insertUserAndUpdateId(owner);
 
             ownerMapper.insertOwner(owner);
-            ownerMapper.insertOwnerShopAttachment(OwnerConverter.INSTANCE.toOwnerShopAttachments(owner));
+            ownerMapper.insertOwnerAttachments(OwnerConverter.INSTANCE.toOwnerAttachments(owner));
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -158,12 +158,15 @@ public class OwnerServiceImpl implements OwnerService {
 //        return UserConverter.INSTANCE.toStudentResponse(studentInToken);
     }
 
-    private static void updateAttachment(OwnerAttachments ownerAttachments, Owner ownerInToken) {
+    private void updateAttachment(OwnerAttachments ownerAttachments, Owner ownerInToken) {
         //PK를 url로? // 중복이 생김 // 중복 체크 ? // 사장님 ID까지 PK로 넣기?
         Set<String> existAttachmentUrls = OwnerAttachments.from(ownerInToken.getAttachments()).getExistAttachmentUrls();
 
         OwnerAttachments toAdd = ownerAttachments.selectToAdd(existAttachmentUrls);
         OwnerAttachments toDelete = ownerAttachments.selectToDelete(existAttachmentUrls);
+
+        ownerMapper.insertOwnerAttachments(toAdd);
+        ownerMapper.deleteOwnerAttachmentsLogically(toDelete);
     }
 
     private Owner getOwnerInToken() {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -125,20 +125,21 @@ public class OwnerServiceImpl implements OwnerService {
     @Override
     public void deleteAttachment(Integer attachmentId) {
         Integer userId = jwtValidator.validate().getId();
-
         OwnerAttachment attachmentInDB = ownerMapper.getOwnerAttachmentById(attachmentId.longValue());
 
+        validateInDelete(userId, attachmentInDB);
+
+        ownerMapper.deleteOwnerAttachmentLogically(attachmentId.longValue());
+    }
+
+    private static void validateInDelete(Integer userId, OwnerAttachment attachmentInDB) {
         if(attachmentInDB == null) {
-            return;
-            // throw 첨부파일 낫 파운드
+            throw new BaseException(ExceptionInformation.OWNER_ATTACHMENT_NOT_FOUND);
         }
 
         if(!attachmentInDB.getOwnerId().equals(userId)) {
-            return;
-//            throw new BaseException("소유자가 아닙니당")
+            throw new BaseException(ExceptionInformation.FORBIDDEN);
         }
-
-
     }
 
     private void validateEmailUniqueness(EmailAddress emailAddress) {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -139,6 +139,7 @@ public class OwnerServiceImpl implements OwnerService {
         Owner owner = OwnerConverter.INSTANCE.toOwner(ownerUpdateRequest);
         Owner ownerInToken = getOwnerInToken();
 
+        owner.setId(ownerInToken.getId());
         updateDBFor(owner, ownerInToken);
 
         return OwnerConverter.INSTANCE.toOwnerResponse(ownerInToken);

--- a/src/main/java/koreatech/in/service/UserService.java
+++ b/src/main/java/koreatech/in/service/UserService.java
@@ -6,7 +6,7 @@ import koreatech.in.dto.normal.user.request.AuthTokenRequest;
 import koreatech.in.dto.normal.user.request.CheckExistsEmailRequest;
 import koreatech.in.dto.normal.user.request.FindPasswordRequest;
 import koreatech.in.dto.normal.user.request.LoginRequest;
-import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
+import koreatech.in.dto.normal.user.student.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
 import koreatech.in.dto.normal.user.response.LoginResponse;
 import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -21,7 +21,7 @@ import koreatech.in.dto.normal.user.request.AuthTokenRequest;
 import koreatech.in.dto.normal.user.request.CheckExistsEmailRequest;
 import koreatech.in.dto.normal.user.request.FindPasswordRequest;
 import koreatech.in.dto.normal.user.request.LoginRequest;
-import koreatech.in.dto.normal.user.request.StudentUpdateRequest;
+import koreatech.in.dto.normal.user.student.request.StudentUpdateRequest;
 import koreatech.in.dto.normal.user.response.AuthResponse;
 import koreatech.in.dto.normal.user.response.LoginResponse;
 import koreatech.in.dto.normal.user.student.request.StudentRegisterRequest;
@@ -199,11 +199,14 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     }
 
     private Student getStudentInToken() {
-        Student studentInToken = studentMapper.getStudentById(jwtValidator.validate().getId());
+        User validatedUser = jwtValidator.validate();
 
-        if (studentInToken == null) {
+        if(!(validatedUser instanceof Student)) {
             throw new BaseException(ExceptionInformation.BAD_ACCESS);
         }
+
+        Student studentInToken = (Student) validatedUser;
+
         return studentInToken;
     }
 
@@ -211,6 +214,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     // TODO 23.02.12. 박한수 개편 필요.. (사장님 관련 UPDATE는 아직 건드리지 않았음.)
     @Override
     @Transactional
+    @Deprecated
     public Map<String, Object> updateOwnerInformation(Owner owner) throws Exception {
         Owner user_old;
         try {

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -205,9 +205,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
             throw new BaseException(ExceptionInformation.BAD_ACCESS);
         }
 
-        Student studentInToken = (Student) validatedUser;
-
-        return studentInToken;
+        return (Student) validatedUser;
     }
 
     // TODO owner 정보 업데이트

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -63,13 +63,14 @@
                 #{company_registration_number});
     </insert>
 
-    <insert id="insertOwnerAttachments" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO koin.owner_shop_attachment (
+    <insert id="insertOwnerAttachments">
+        INSERT INTO koin.owner_shop_attachment
+        (
         owner_id,
         url
         )
         VALUES
-        <foreach item="ownerAttachment" collection="attachments" separator=",">
+        <foreach collection="attachments" item="ownerAttachment" separator=",">
             (
             #{ownerAttachment.ownerId},
             #{ownerAttachment.fileUrl}

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -81,7 +81,7 @@
         UPDATE koin.owner_shop_attachment
         SET is_deleted = TRUE
         <foreach item="ownerAttachment" collection="attachments" separator=",">
-            WHERE url = #{fileUrl}
+            WHERE url = #{ownerAttachment.fileUrl}
         </foreach>
     </update>
 

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -63,22 +63,27 @@
                 #{company_registration_number});
     </insert>
 
-    <insert id="insertOwnerShopAttachment" parameterType="koreatech.in.domain.User.owner.OwnerAttachments">
+    <insert id="insertOwnerAttachments">
         INSERT INTO koin.owner_shop_attachment (
-        shop_id,
         owner_id,
         url
         )
         VALUES
         <foreach item="ownerAttachment" collection="attachments" separator=",">
             (
-            #{ownerAttachment.shopId},
             #{ownerAttachment.ownerId},
             #{ownerAttachment.fileUrl}
             )
         </foreach>
     </insert>
 
+    <update id="deleteOwnerAttachmentLogically">
+        UPDATE koin.owner_shop_attachment
+        SET is_deleted = TRUE
+        <foreach item="ownerAttachment" collection="attachments" separator=",">
+            WHERE url = #{fileUrl}
+        </foreach>
+    </update>
 
     <select id="getOwnerAttachmentById" resultMap="ownerAttachmentResultMap">
         SELECT id,

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -88,4 +88,10 @@
         WHERE id = #{id}
           AND is_deleted = FALSE
     </select>
+
+    <update id="deleteOwnerAttachmentLogically">
+        UPDATE koin.owner_shop_attachment
+        SET is_deleted = TRUE
+        WHERE id = #{id}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -77,6 +77,21 @@
         </foreach>
     </insert>
 
+    <insert id="insertOwnerAttachment" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO koin.owner_shop_attachment
+        (
+        owner_id,
+        url
+        )
+        VALUES
+
+        (
+        #{ownerId},
+        #{fileUrl}
+        )
+    </insert>
+
+
     <update id="deleteOwnerAttachmentsLogically">
         UPDATE koin.owner_shop_attachment
         SET is_deleted = TRUE

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -93,10 +93,10 @@
 
 
     <update id="deleteOwnerAttachmentsLogically">
-        UPDATE koin.owner_shop_attachment
-        SET is_deleted = TRUE
-        <foreach item="ownerAttachment" collection="attachments" separator=",">
-            WHERE url = #{ownerAttachment.fileUrl}
+        <foreach item="ownerAttachment" collection="attachments" separator=";">
+            UPDATE koin.owner_shop_attachment
+            SET is_deleted = TRUE
+            WHERE id = #{ownerAttachment.id}
         </foreach>
     </update>
 

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -63,7 +63,7 @@
                 #{company_registration_number});
     </insert>
 
-    <insert id="insertOwnerAttachments">
+    <insert id="insertOwnerAttachments" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO koin.owner_shop_attachment (
         owner_id,
         url

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -77,7 +77,7 @@
         </foreach>
     </insert>
 
-    <update id="deleteOwnerAttachmentLogically">
+    <update id="deleteOwnerAttachmentsLogically">
         UPDATE koin.owner_shop_attachment
         SET is_deleted = TRUE
         <foreach item="ownerAttachment" collection="attachments" separator=",">

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -26,6 +26,11 @@
         <result property="name" column="name"/>
     </resultMap>
 
+    <resultMap id="ownerAttachmentResultMap" type="koreatech.in.domain.User.owner.OwnerAttachment">
+        <id property="id" column="attachment_id"/>
+        <result property="ownerId" column="owner_id"/>
+    </resultMap>
+
     <select id="getOwnerById" resultMap="ownerShopsResultMap">
         SELECT users.id                           AS id,
                users.email                        AS email,
@@ -73,4 +78,14 @@
             )
         </foreach>
     </insert>
+
+
+    <select id="getOwnerAttachmentById" resultMap="ownerAttachmentResultMap">
+        SELECT id,
+               owner_id
+        FROM koin.owner_shop_attachment
+
+        WHERE id = #{id}
+          AND is_deleted = FALSE
+    </select>
 </mapper>


### PR DESCRIPTION
# Feature: 사장님 업데이트 API

## Task: 첨부파일 삭제 API

**기능 변경사항**

- `DELETE /owners/attachment/{id}` API 생성

**코드 구현사항**

- Controller & Service에 `deleteAttachment` 메서드 추가
- Repository에  `deleteOwnerAttachmentLogically` 메서드 추가
- 첨부파일을 못 찾은 경우에 대한 예외 추가

## Task: 사장님 업데이트 API

**기능 변경사항**

`PUT /owner` API를 생성하였다.

**코드 구현사항**

- Controller, Service에 `update()` 메서드 생성 후 구현하였다.
- Repository에 `insertOwnerAttachment()`, `deleteOwnerAttachmentsLogically()` 메서드 생성 후 구현하였다.
- `OwnerAttachment` 객체 내부에서 추가할 첨부파일과 제거할 첨부파일을 구분하기 위해 집합을 이용하였다.
- JwtValidator에서 **이중 접근 문제*를 해결하기 위해 JWT를 파싱하여 ID만 가져오는 메서드를 생성

**이중 접근 문제*

1. JWT Token을 이용하여 ID를 추출
2. ID를 이용하여 **DB**에 있는 User를 반환
3. 이 User의 ID를 이용하여 **DB**에 있는 Owner or Student를 탐색

→ DB에 두번 접근함.

**기타 특이사항**

- 위와 동일하게 파일URL 배열을 Update하는 로직인 AdminLand의 Update(`DB 상에 lands.image_urls` ) 변경시 이번 PR을 참고하면 유용할 것 같다.
- mybatis-foreach 문을 이용하여 insert 했을 때, Insert 이후의 ID들을 목록으로 가져와지지가 않아 `insertOwnerAttachments()` 대신 `insertOwnerAttachment()` + 반복문을 이용하여 DB에 삽입하였다.

