### PR TITLE
Fix: 시외버스 스케줄링 정지

### DIFF
--- a/src/main/java/koreatech/in/schedule/BusTago.java
+++ b/src/main/java/koreatech/in/schedule/BusTago.java
@@ -22,7 +22,7 @@ public class BusTago {
 
     // 하루에 한 번으로 지정하려했지만, 공공 데이터 API 호출 결과 00시에 바로 업데이트 되지 않음을 확인
     // 이전보다 더 잦게 스케줄링하도록 변경
-    @Scheduled(cron = "0 */2 * * * *")
+//    @Scheduled(cron = "0 */2 * * * *")
     public void handleIntercityBus() {
         intercityBus.cacheBusArrivalInfo();
     }


### PR DESCRIPTION
## Fix: 시외버스 스케줄링 정지

**기능 변경사항**

- 시외버스 데이터를 공공데이터 포털 API에서 Redis로 저장하는 스케줄링 기능 정지

**코드 구현사항**

- 시외버스 스케줄링 애너테이션 주석 처리

**기타 특이사항**
- 당분간 수동기입한 데이터를 Redis에 삽입하여 이용할 예정
- #195 