### PR TITLE
Feature: 버스 스케줄링시 버전 기입

### DIFF
--- a/src/main/java/koreatech/in/controller/VersionController.java
+++ b/src/main/java/koreatech/in/controller/VersionController.java
@@ -2,14 +2,16 @@ package koreatech.in.controller;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
+import javax.inject.Inject;
 import koreatech.in.domain.Version.Version;
 import koreatech.in.service.VersionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-
-import javax.inject.Inject;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @Api(tags = "(Normal) Version", description = "버전")
 @Controller
@@ -19,8 +21,16 @@ public class VersionController {
 
     @RequestMapping(value = "/versions/{type}", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity getVersion(@ApiParam(required = true) @PathVariable(value = "type") String type) throws Exception {
+    ResponseEntity<Version> getVersion(
+            @PathVariable(value = "type")
+            @ApiParam(value = "타입 이름 \n\n"
+                    + "- `android` (안드로이드)\n"
+                    + "- `shuttle_bus_timetable` (셔틀, 통학 버스)\n"
+                    + "- `express_bus_timetable` (대성 고속)\n"
+                    + "- `city_bus_timetable` (시내 버스)\n"
+                    , example = "city_bus_timetable", required = true)
+            String type) throws Exception {
 
-        return new ResponseEntity<Version>(versionService.getVersion(type), HttpStatus.OK);
+        return new ResponseEntity<>(versionService.getVersion(type), HttpStatus.OK);
     }
 }

--- a/src/main/java/koreatech/in/domain/Bus/Bus.java
+++ b/src/main/java/koreatech/in/domain/Bus/Bus.java
@@ -1,10 +1,6 @@
 package koreatech.in.domain.Bus;
 
 import com.google.gson.Gson;
-import koreatech.in.util.StringRedisUtilObj;
-import koreatech.in.util.StringRedisUtilStr;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -13,6 +9,13 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import koreatech.in.domain.Version.BatchVersion;
+import koreatech.in.domain.Version.VersionTypeEnum;
+import koreatech.in.repository.VersionMapper;
+import koreatech.in.util.StringRedisUtilObj;
+import koreatech.in.util.StringRedisUtilStr;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class Bus {
 
@@ -23,6 +26,9 @@ public abstract class Bus {
 
     @Autowired
     StringRedisUtilStr stringRedisUtilStr;
+
+    @Autowired
+    VersionMapper versionMapper;
 
     String requestOpenAPI(String urlBuilder) {
 
@@ -57,6 +63,15 @@ public abstract class Bus {
     public abstract List<? extends BusTimetable> getTimetables(String busType, String direction, String region);
 
     public abstract void cacheBusArrivalInfo();
+
+    public abstract VersionTypeEnum getVersionType();
+
+    protected void updateVersion() {
+        VersionTypeEnum typeEnum = Optional.ofNullable(getVersionType())
+                .orElseThrow(UnsupportedOperationException::new);
+
+        versionMapper.upsertBusVersion(BatchVersion.from(typeEnum));
+    }
 
     public abstract SingleBusTime searchBusTime(String busType, String depart, String arrival, LocalDateTime at);
 }

--- a/src/main/java/koreatech/in/domain/Bus/CityBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/CityBus.java
@@ -5,13 +5,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-import koreatech.in.domain.NotiSlack;
-import koreatech.in.util.SlackNotiSender;
-import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
@@ -27,6 +20,13 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import koreatech.in.domain.NotiSlack;
+import koreatech.in.domain.Version.VersionTypeEnum;
+import koreatech.in.util.SlackNotiSender;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 @Component
 public class CityBus extends Bus {
@@ -41,6 +41,8 @@ public class CityBus extends Bus {
 
     private static final Type arrivalInfoType = new TypeToken<List<CityBusArrivalInfo>>() {
     }.getType();
+
+    private static final VersionTypeEnum BUS_VERSION_TYPE = VersionTypeEnum.CITY;
 
     @Value("${OPEN_API_KEY}")
     private String OPEN_API_KEY;
@@ -157,6 +159,13 @@ public class CityBus extends Bus {
         for (String nodeID : BusNodeEnum.nodeIDs) {
             getArrivalTimesFromReal(nodeID);
         }
+
+        updateVersion();
+    }
+
+    @Override
+    public VersionTypeEnum getVersionType() {
+        return BUS_VERSION_TYPE;
     }
 
     @Override

--- a/src/main/java/koreatech/in/domain/Bus/IntercityBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/IntercityBus.java
@@ -5,20 +5,15 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-import koreatech.in.domain.NotiSlack;
-import koreatech.in.mapstruct.normal.bus.IntercityBusTimetableConverter;
-import koreatech.in.util.SlackNotiSender;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.URLEncoder;
-import java.time.*;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -26,6 +21,15 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import koreatech.in.domain.NotiSlack;
+import koreatech.in.domain.Version.VersionTypeEnum;
+import koreatech.in.mapstruct.normal.bus.IntercityBusTimetableConverter;
+import koreatech.in.util.SlackNotiSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 @Component
 public class IntercityBus extends Bus {
@@ -39,6 +43,8 @@ public class IntercityBus extends Bus {
 
     private static final Type timetableType = new TypeToken<List<IntercityBusTimetable>>() {
     }.getType();
+
+    public static final VersionTypeEnum BUS_VERSION_TYPE = VersionTypeEnum.EXPRESS;
 
     @Value("${OPEN_API_KEY}")
     private String OPEN_API_KEY;
@@ -206,8 +212,16 @@ public class IntercityBus extends Bus {
     public void cacheBusArrivalInfo() {
         BusTerminalEnum koreatech = BusTerminalEnum.KOREATECH;
         BusTerminalEnum terminal = BusTerminalEnum.TERMINAL;
+
         getArrivalTimesFromReal(koreatech, terminal);
         getArrivalTimesFromReal(terminal, koreatech);
+
+        updateVersion();
+    }
+
+    @Override
+    public VersionTypeEnum getVersionType() {
+        return BUS_VERSION_TYPE;
     }
 
     @Override

--- a/src/main/java/koreatech/in/domain/Bus/SchoolBus.java
+++ b/src/main/java/koreatech/in/domain/Bus/SchoolBus.java
@@ -5,19 +5,23 @@ import com.mongodb.AggregationOutput;
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
-import koreatech.in.repository.BusRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-
 import java.lang.reflect.Type;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Pattern;
+import koreatech.in.domain.Version.VersionTypeEnum;
+import koreatech.in.repository.BusRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 public abstract class SchoolBus extends Bus {
 
@@ -30,6 +34,7 @@ public abstract class SchoolBus extends Bus {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
 
     @Override
     public BusRemainTime getNowAndNextBusRemainTime(String busType, String depart, String arrival) {
@@ -225,6 +230,16 @@ public abstract class SchoolBus extends Bus {
 
     @Override
     public void cacheBusArrivalInfo() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VersionTypeEnum getVersionType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateVersion() {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/koreatech/in/domain/Version/BatchVersion.java
+++ b/src/main/java/koreatech/in/domain/Version/BatchVersion.java
@@ -1,0 +1,27 @@
+package koreatech.in.domain.Version;
+
+import koreatech.in.util.DateUtil;
+import lombok.Getter;
+
+@Getter
+public class BatchVersion {
+    private static final Character ZERO_PADDING = '0';
+    private final String version;
+    private final VersionTypeEnum type;
+
+    private BatchVersion(String version, VersionTypeEnum type) {
+        this.version = version;
+        this.type = type;
+    }
+
+    public static BatchVersion from(VersionTypeEnum type) {
+        return new BatchVersion(makeVersion(), type);
+    }
+
+    private static String makeVersion() {
+        return String.format("%s%c_%d", DateUtil.getYearOfNow(), ZERO_PADDING, DateUtil.getTimeStampSecondOfNow() );
+    }
+    public String getType() {
+        return type.getType();
+    }
+}

--- a/src/main/java/koreatech/in/domain/Version/Version.java
+++ b/src/main/java/koreatech/in/domain/Version/Version.java
@@ -16,10 +16,10 @@ public class Version {
     @NotNull(groups = { ValidationGroups.CreateAdmin.class }, message = "타입은 비워둘 수 없습니다.")
     @ApiModelProperty(notes = "타입", example = "android")
     private String type;
-    @ApiModelProperty(hidden = true)
+    @ApiModelProperty(notes = "생성 일자", example = "2018-04-18 09:00:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private Date created_at;
-    @ApiModelProperty(hidden = true)
+    @ApiModelProperty(notes = "수정 일자", example = "2018-04-18 09:00:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private Date updated_at;
 

--- a/src/main/java/koreatech/in/domain/Version/VersionTypeEnum.java
+++ b/src/main/java/koreatech/in/domain/Version/VersionTypeEnum.java
@@ -1,0 +1,17 @@
+package koreatech.in.domain.Version;
+
+public enum VersionTypeEnum {
+    CITY("city_bus_timetable"),
+    EXPRESS("express_bus_timetable"),
+    ;
+
+    private final String type;
+
+    VersionTypeEnum(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/koreatech/in/repository/VersionMapper.java
+++ b/src/main/java/koreatech/in/repository/VersionMapper.java
@@ -1,5 +1,6 @@
 package koreatech.in.repository;
 
+import koreatech.in.domain.Version.BatchVersion;
 import koreatech.in.domain.Version.Version;
 import org.apache.ibatis.annotations.*;
 import org.springframework.stereotype.Repository;
@@ -25,4 +26,8 @@ public interface VersionMapper {
 
     @Delete("DELETE FROM koin.versions WHERE TYPE = #{type}")
     void deleteVersionForAdmin(@Param("type") String type);
+
+    @Insert("INSERT INTO versions (version, type) VALUES (#{version}, #{type}) ON DUPLICATE KEY UPDATE version = #{version};")
+    void upsertBusVersion(BatchVersion batchVersion);
+
 }

--- a/src/main/java/koreatech/in/util/DateUtil.java
+++ b/src/main/java/koreatech/in/util/DateUtil.java
@@ -1,9 +1,22 @@
 package koreatech.in.util;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 
 public class DateUtil {
+    public static final ZoneId KST_TIMEZONE = ZoneId.of("Asia/Seoul");
+
+    public static Integer getYearOfNow() {
+        return LocalDateTime.ofInstant(Instant.now(), KST_TIMEZONE).getYear();
+    }
+
+    public static Long getTimeStampSecondOfNow() {
+        return Instant.now().getEpochSecond();
+    }
+
     public static Date addHoursToJavaUtilDate(Date date, int hours) {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);

--- a/src/main/resources/db/migration/V71.000__increase_version_type_size.sql
+++ b/src/main/resources/db/migration/V71.000__increase_version_type_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE versions MODIFY COLUMN `type` VARCHAR(255);


### PR DESCRIPTION
# Feature: 버스 스케줄링시 버전 기입

### as-is
- 버스 스케줄링을 버전에 기입하지 않음
### to-be
- 버스 스케줄링 결과를 버전에 기입
  - 시내버스, 대성고속(지금은 막혀있음)을 각각 city_bus_timetable, express_bus_timetable을 기입함.
- dateutil에서 버전 기입시 활용하기 위한 `현재의 유닉스타임 & 현재 년도` 을 가져오는 기능 추가.
- Mysql, versions.type의 크기를 증가시킴.


**기타 사항**
- flyway ~V71 사용.
- 현재는 막힌 대성고속의 변경을 DB상에 수동 기입할 계획.