### PR TITLE
docs: 버전API 응답 문서 표현 변경

### DIFF
--- a/src/main/java/koreatech/in/controller/VersionController.java
+++ b/src/main/java/koreatech/in/controller/VersionController.java
@@ -28,7 +28,7 @@ public class VersionController {
     @ApiResponses({
             @ApiResponse(code = 404, message
                     = "- 존재하지 않는 버전 타입일 때 (code: 122000) \n\n"
-                    + "- 아이디에 대한 회원 정보가 없을 때 (code: 101000) \n\n"
+                    + "- 버전 타입에 해당하는 버전이 없을 때 (code: 122001) \n\n"
                     , response = ExceptionResponse.class),
     })
     @RequestMapping(value = "/versions/{type}", method = RequestMethod.GET)


### PR DESCRIPTION
# docs: 버전API 응답 문서 표현 변경

### as-is
- 복사 붙여넣기 이후 수정하지 않아 API 문서에서 잘못된 표현을 하고있었음.
### to-be
- 전하려고 했던 표현으로 정정.