### PR TITLE
Fix: 버전 타입 시간표(`timetable`) 추가

### DIFF
--- a/src/main/java/koreatech/in/domain/Version/VersionTypeEnum.java
+++ b/src/main/java/koreatech/in/domain/Version/VersionTypeEnum.java
@@ -8,6 +8,7 @@ import koreatech.in.exception.ExceptionInformation;
 
 public enum VersionTypeEnum {
     ANDROID("android"),
+    TIMETABLE("timetable"),
     SHUTTLE("shuttle_bus_timetable"),
     CITY("city_bus_timetable"),
     EXPRESS("express_bus_timetable"),


### PR DESCRIPTION
# Fix: 버전 타입 시간표(`timetable`) 추가

### as-is
- timetable에 대한 version type이 없음.
### to-be
- timetable에 대한 version type 추가.