### PR TITLE
docs: API 문서에 누락된 버전 타입 시간표(`timetable`) 추가

### DIFF
--- a/src/main/java/koreatech/in/controller/VersionController.java
+++ b/src/main/java/koreatech/in/controller/VersionController.java
@@ -37,6 +37,7 @@ public class VersionController {
             @PathVariable(value = "type")
             @ApiParam(value = "타입 이름 \n\n"
                     + "- `android`(안드로이드)\n"
+                    + "- `timetable`(시간표)\n"
                     + "- `shuttle_bus_timetable`(셔틀, 통학 버스)\n"
                     + "- `express_bus_timetable`(대성 고속)\n"
                     + "- `city_bus_timetable`(시내 버스)\n"


### PR DESCRIPTION
# docs: 버전 타입 시간표(`timetable`)를 API 문서에 추가

### as-is
- API문서의 version type에 timetable 누락

### to-be
- API문서의 version type에 timetable 추가