### PR TITLE
Refactor: 어드민 학생 조회 API

### DIFF
--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -86,13 +86,14 @@ public class AdminUserController {
         return new ResponseEntity<>(adminUserService.getUserForAdmin(id), HttpStatus.OK);
     }
 
-    @ApiOperation(value = "특정 학생 조회", authorizations = {@Authorization("Authorization")})
+    @ApiOperation(value = "특정 학생 조회", notes = "- 어드민 권한만 허용", authorizations = {@Authorization("Authorization")})
     @ApiResponses({
             @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
                                                "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
                                                "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
-            @ApiResponse(code = 404, message = "- 조회한 회원이 존재하지 않을 때 (code: 101003)", response = ExceptionResponse.class)
+            @ApiResponse(code = 404, message = "- 조회한 회원이 존재하지 않을 때 (code: 101003)", response = ExceptionResponse.class),
+            @ApiResponse(code = 409, message = "- 조회한 id가 학생이 아닐 떄 (code: 101017)", response = ExceptionResponse.class)
     })
     @RequestMapping(value = "/admin/users/student/{id}", method = RequestMethod.GET)
     public @ResponseBody

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -93,7 +93,7 @@ public class AdminUserController {
                                                "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
             @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
             @ApiResponse(code = 404, message = "- 조회한 회원이 존재하지 않을 때 (code: 101003)", response = ExceptionResponse.class),
-            @ApiResponse(code = 409, message = "- 조회한 id가 학생이 아닐 떄 (code: 101017)", response = ExceptionResponse.class)
+            @ApiResponse(code = 409, message = "- 조회한 id가 학생이 아닐 때 (code: 101017)", response = ExceptionResponse.class)
     })
     @RequestMapping(value = "/admin/users/student/{id}", method = RequestMethod.GET)
     public @ResponseBody

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -32,7 +32,7 @@ public enum ExceptionInformation {
     EMAIL_DOMAIN_IS_NOT_PORTAL_DOMAIN("한국기술교육대학교 포탈의 이메일 형식('koreatech.ac.kr')이 아닙니다.", 101014, HttpStatus.UNPROCESSABLE_ENTITY),
     STUDENT_NUMBER_INVALID("학생의 학번 형식이 아닙니다.", 101015, HttpStatus.UNPROCESSABLE_ENTITY),
     STUDENT_MAJOR_INVALID("학생의 전공 형식이 아닙니다.", 101016, HttpStatus.UNPROCESSABLE_ENTITY),
-    NOT_STUDENT("회원의 신원이 학생이 아닙니다.", 101017, HttpStatus.NOT_FOUND),
+    NOT_STUDENT("회원의 신원이 학생이 아닙니다.", 101017, HttpStatus.CONFLICT),
 
     // ======= 상점 ========
     SHOP_NOT_FOUND("상점이 존재하지 않습니다.", 104000, HttpStatus.NOT_FOUND),


### PR DESCRIPTION
### admin-get-student-api : admin 페이지에서 특정 학생을 조회하는 api

---
__< 변경 전 >__
- swagger에 접근 가능한 권한이 명시되어 있지 않음 
- 학생 id가 아닐 경우 404 에러가 발생함


__< 변경 후 >__
- swagger에 admin 권한만 허용됨을 명시
- 학생 id가 아닐 경우 409 에러가 발생함

