### PR TITLE
Refactor : shop 조회 response에 updated_at 추가

### DIFF
--- a/src/main/java/koreatech/in/domain/Shop/ShopProfile.java
+++ b/src/main/java/koreatech/in/domain/Shop/ShopProfile.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.DayOfWeek;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,7 @@ public class ShopProfile {
     private List<ShopCategory> shop_categories;
     private List<MenuCategory> menu_categories;
     private Boolean is_deleted;
+    private Date updated_at;
 
     @Getter
     public static final class Open {

--- a/src/main/java/koreatech/in/dto/normal/shop/response/ShopResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/response/ShopResponse.java
@@ -1,11 +1,13 @@
 package koreatech.in.dto.normal.shop.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.DayOfWeek;
+import java.util.Date;
 import java.util.List;
 
 @Getter @Builder
@@ -48,6 +50,10 @@ public class ShopResponse {
 
     @ApiModelProperty(notes = "상점에 있는 메뉴 카테고리 리스트", required = true)
     private List<MenuCategory> menu_categories;
+
+    @ApiModelProperty(value = "업데이트 일자", example = "2023-01-01 12:01:02", required = true)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private Date updated_at;
 
     @Getter @Builder
     @ApiModel("Open_4")

--- a/src/main/resources/db/migration/V72.000_create_trigger_opens.sql
+++ b/src/main/resources/db/migration/V72.000_create_trigger_opens.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+CREATE TRIGGER update_shop_updated_at_opens
+    AFTER UPDATE
+    ON shop_opens
+    FOR EACH ROW
+
+BEGIN
+    UPDATE shops SET updated_at = NEW.updated_at WHERE shops.id = NEW.shop_id;
+END $$
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V72.001_create_trigger_category.sql
+++ b/src/main/resources/db/migration/V72.001_create_trigger_category.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+CREATE TRIGGER update_shop_updated_at_category
+    AFTER UPDATE
+    ON shop_category_map
+    FOR EACH ROW
+
+BEGIN
+    UPDATE shops SET updated_at = NEW.updated_at WHERE shops.id = NEW.shop_id;
+END $$
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V72.002_create_trigger_images.sql
+++ b/src/main/resources/db/migration/V72.002_create_trigger_images.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+CREATE TRIGGER update_shop_updated_at_images
+    AFTER UPDATE
+    ON shop_images
+    FOR EACH ROW
+
+BEGIN
+    UPDATE shops SET updated_at = NEW.updated_at WHERE shops.id = NEW.shop_id;
+END $$
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V72.003_create_trigger_menus.sql
+++ b/src/main/resources/db/migration/V72.003_create_trigger_menus.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+CREATE TRIGGER update_shop_updated_at_menus
+    AFTER UPDATE
+    ON shop_menus
+    FOR EACH ROW
+
+BEGIN
+    UPDATE shops SET updated_at = NEW.updated_at WHERE shops.id = NEW.shop_id;
+END $$
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V72.004_create_trigger_menu_categories.sql
+++ b/src/main/resources/db/migration/V72.004_create_trigger_menu_categories.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+CREATE TRIGGER update_shop_updated_at_menus_category
+    AFTER UPDATE
+    ON shop_menu_category_map
+    FOR EACH ROW
+
+BEGIN
+    UPDATE shop_menus SET updated_at = NEW.updated_at WHERE shop_menus.id = NEW.shop_menu_id;
+END $$
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V72.005_create_trigger_menu_details.sql
+++ b/src/main/resources/db/migration/V72.005_create_trigger_menu_details.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+CREATE TRIGGER update_shop_updated_at_menus_detatils
+    AFTER UPDATE
+    ON shop_menu_details
+    FOR EACH ROW
+
+BEGIN
+    UPDATE shop_menus SET updated_at = NEW.updated_at WHERE shop_menus.id = NEW.shop_menu_id;
+END $$
+
+DELIMITER ;

--- a/src/main/resources/db/migration/V72.006_create_trigger_menu_images.sql
+++ b/src/main/resources/db/migration/V72.006_create_trigger_menu_images.sql
@@ -1,0 +1,12 @@
+DELIMITER $$
+
+CREATE TRIGGER update_shop_updated_at_menus_images
+    AFTER UPDATE
+    ON shop_menu_images
+    FOR EACH ROW
+
+BEGIN
+    UPDATE shop_menus SET updated_at = NEW.updated_at WHERE shop_menus.id = NEW.shop_menu_id;
+END $$
+
+DELIMITER ;

--- a/src/main/resources/mapper/normal/ShopMapper.xml
+++ b/src/main/resources/mapper/normal/ShopMapper.xml
@@ -21,6 +21,7 @@
             `t1`.`pay_card` AS `shops.pay_card`,
             `t1`.`pay_bank` AS `shops.pay_bank`,
             `t1`.`is_deleted` AS `shops.is_deleted`,
+            `t1`.`updated_at` AS `shops.updated_at`,
 
             # shop_opens
             `t2`.`day_of_week` AS `shop_opens.day_of_week`,
@@ -642,6 +643,7 @@
         <result property="pay_card" column="shops.pay_card"/>
         <result property="pay_bank" column="shops.pay_bank"/>
         <result property="is_deleted" column="shops.is_deleted"/>
+        <result property="updated_at" column="shops.updated_at"/>
 
         <collection property="open" javaType="list" ofType="koreatech.in.domain.Shop.ShopProfile$Open">
             <result property="day_of_week" column="shop_opens.day_of_week" />


### PR DESCRIPTION
### user가 상점을 조회할 때 update된 날짜도 반환

---
__< 변경 전 >__
- 상점을 조회해도 update된 날짜가 나오지 않음

__< 변경 후 >__
- 상점 조회 시 update된 날짜가 나옴
  -  카테고리, 메뉴, 이미지, open 정보를 업데이트 했을 때 shop 테이블의 `updated_at`이 변경됨
---
상점을 업데이트 할 경우 상점 테이블에 포함된 데이터가 변경될 경우 updated_at이 변경되지만, 상점 테이블이 아닌 상점테이블의 id를 참조하는 테이블의 정보만 변경될 경우 그 테이블의 updated_at만 변경됩니다.
상점 테이블을 참조하는 다른 테이블을 변경 했을 때에도 상점 테이블의 updated_at을 변경하여 업데이트된 날짜를 통일하기 위해 다른 테이블들과 동기화가 필요했습니다. 이를 위해 trigger를 사용하였습니다.

---
trigger 생성 문법
```sql
DELIMITER $$

CREATE TRIGGER update_item
AFTER UPDATE  -- {BEFORE | AFTER} {INSERT | UPDATE| DELETE } 중 언제 어떤 작업을 할지 정한다
ON sale_table -- 트리거를 부착할 테이블
FOR EACH ROW -- 아래 나올 조건에 해당하는 모든 row에 적용한다는 뜻

BEGIN
  -- 트리거시 실행되는 코드
  IF NEW.discount_rate != OLD.discount_rate THEN -- update 트리거는 old와 new 값이 존재한다.
    UPDATE item_table SET discount_rate = NEW.discount_rate WHERE discount_rate = OLD.discount_rate;
  END IF;
END $$

DELIMITER ;
```
---
사용 예시
```sql
DELIMITER $$

CREATE TRIGGER update_shop_updated_at_opens
AFTER UPDATE  
ON shop_opens 
FOR EACH ROW

BEGIN
    UPDATE shops SET updated_at = NEW.updated_at WHERE shops.id = NEW.shop_id;
END $$

DELIMITER ;
```