### PR TITLE
Refactor: updated_at 응답 길이 축소

### DIFF
--- a/src/main/java/koreatech/in/domain/Dining/DiningMenuDTO.java
+++ b/src/main/java/koreatech/in/domain/Dining/DiningMenuDTO.java
@@ -2,12 +2,11 @@ package koreatech.in.domain.Dining;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.Date;
+import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
 import org.springframework.util.StringUtils;
-
-import java.util.Date;
-import java.util.List;
 
 @Getter
 @ToString
@@ -42,7 +41,7 @@ public class DiningMenuDTO {
     private final Date created_at;
 
     @ApiModelProperty(hidden = true)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private final Date updated_at;
 
     public DiningMenuDTO(Integer id, String date, String type, String place, Integer price_card, Integer price_cash, Integer kcal, List<String> menu, Date created_at, Date updated_at) {

--- a/src/main/java/koreatech/in/domain/Dining/DiningMenuDTO.java
+++ b/src/main/java/koreatech/in/domain/Dining/DiningMenuDTO.java
@@ -40,11 +40,10 @@ public class DiningMenuDTO {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private final Date created_at;
 
-    @ApiModelProperty(hidden = true)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-    private final Date updated_at;
+    @ApiModelProperty(notes = "최신화 일자", example = "2023-04-19")
+    private final String updated_at;
 
-    public DiningMenuDTO(Integer id, String date, String type, String place, Integer price_card, Integer price_cash, Integer kcal, List<String> menu, Date created_at, Date updated_at) {
+    public DiningMenuDTO(Integer id, String date, String type, String place, Integer price_card, Integer price_cash, Integer kcal, List<String> menu, Date created_at, String updated_at) {
         this.id = id;
         this.date = date;
         this.type = type;
@@ -77,4 +76,5 @@ public class DiningMenuDTO {
         }
         return kcal;
     }
+
 }

--- a/src/main/java/koreatech/in/domain/Global/UpdatedAt.java
+++ b/src/main/java/koreatech/in/domain/Global/UpdatedAt.java
@@ -1,0 +1,24 @@
+package koreatech.in.domain.Global;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class UpdatedAt {
+    private static final String DATE_FORM = "yyyy-MM-dd";
+    private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(DATE_FORM);
+
+    private final Date updatedAt;
+
+    public UpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public static UpdatedAt from(Date updatedAt) {
+        return new UpdatedAt(updatedAt);
+    }
+
+    public String dateForm() {
+        return SIMPLE_DATE_FORMAT.format(updatedAt);
+    }
+
+}

--- a/src/main/java/koreatech/in/domain/Global/UpdatedAt.java
+++ b/src/main/java/koreatech/in/domain/Global/UpdatedAt.java
@@ -2,20 +2,14 @@ package koreatech.in.domain.Global;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor(staticName = "from")
 public class UpdatedAt {
     private static final String DATE_FORM = "yyyy-MM-dd";
     private static final SimpleDateFormat SIMPLE_DATE_FORMAT = new SimpleDateFormat(DATE_FORM);
 
     private final Date updatedAt;
-
-    public UpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public static UpdatedAt from(Date updatedAt) {
-        return new UpdatedAt(updatedAt);
-    }
 
     public String dateForm() {
         return SIMPLE_DATE_FORMAT.format(updatedAt);

--- a/src/main/java/koreatech/in/domain/Version/Version.java
+++ b/src/main/java/koreatech/in/domain/Version/Version.java
@@ -20,7 +20,7 @@ public class Version {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private Date created_at;
     @ApiModelProperty(notes = "수정 일자", example = "2018-04-18 09:00:00")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private Date updated_at;
 
     public Integer getId() {

--- a/src/main/java/koreatech/in/domain/Version/Version.java
+++ b/src/main/java/koreatech/in/domain/Version/Version.java
@@ -19,7 +19,7 @@ public class Version {
     @ApiModelProperty(notes = "생성 일자", example = "2018-04-18 09:00:00")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private Date created_at;
-    @ApiModelProperty(notes = "수정 일자", example = "2018-04-18 09:00:00")
+    @ApiModelProperty(notes = "수정 일자", example = "2018-04-18")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private Date updated_at;
 

--- a/src/main/java/koreatech/in/mapstruct/normal/dining/DiningMenuConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/normal/dining/DiningMenuConverter.java
@@ -2,15 +2,16 @@ package koreatech.in.mapstruct.normal.dining;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import java.util.Date;
+import java.util.List;
 import koreatech.in.domain.Dining.DiningMenu;
 import koreatech.in.domain.Dining.DiningMenuDTO;
+import koreatech.in.domain.Global.UpdatedAt;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
-
-import java.util.List;
 
 @Mapper
 public interface DiningMenuConverter {
@@ -18,7 +19,8 @@ public interface DiningMenuConverter {
     DiningMenuConverter INSTANCE = Mappers.getMapper(DiningMenuConverter.class);
 
     @Mappings({
-            @Mapping(source = "menu", target = "menu", qualifiedByName = "convertMenu")
+            @Mapping(source = "menu", target = "menu", qualifiedByName = "convertMenu"),
+            @Mapping(source = "updated_at", target = "updated_at", qualifiedByName = "convertUpdatedAt")
     })
     DiningMenuDTO toDiningMenuDTO(DiningMenu diningMenu);
 
@@ -26,5 +28,10 @@ public interface DiningMenuConverter {
     default List<String> convertMenu(String menu) {
         return new Gson().fromJson(menu, new TypeToken<List<String>>() {
         }.getType());
+    }
+
+    @Named("convertUpdatedAt")
+    default String convertUpdatedAt(Date updated_at) {
+        return UpdatedAt.from(updated_at).dateForm();
     }
 }


### PR DESCRIPTION
### as-is
`updated_at` 으로 `2023-04-02 14:22:47` 꼴(yyyy-MM-dd hh:mm:ss)을 반환한다.
### to-be
`updated_at` 으로 **클라이언트에서 사용하는 데이터**꼴인 *DateForm을 반환함. 
(`GET /versions/{type}`, `GET /dinings`에서)

### 앞으로의 변경사항 (UpdatedAt의 길이축소가 필요한 경우)
1. DTO & mapstruct가 완전히 도입된 경우, mapstruct에서 Domain.`UpdatedAt`을 이용하여 DateForm을 구한 뒤 DTO에 넣어준다.
2. DTO & mapstruct가 도입되지 않고 Domain을 반환하는 경우 `@ApiModelProperty`를 변경한다.
3. Map<>을 반환하는 경우는 mysql 쿼리문에서 `DATE(updated_at)`을 활용한다.

단 2,3번은 모두 도입 전까지  **임시로** 활용하는 경우이다.

---
*DateForm: yyyy-MM-dd (`2023-04-02` )

날짜 포맷 관련 [참고문서](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings?redirectedfrom=MSDN)