### PR TITLE
Feature: 키 설정 로직 변경

### DIFF
--- a/src/main/java/koreatech/in/domain/Auth/JWTKeys.java
+++ b/src/main/java/koreatech/in/domain/Auth/JWTKeys.java
@@ -1,0 +1,48 @@
+package koreatech.in.domain.Auth;
+
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+@Getter
+public class JWTKeys {
+    private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    private final SecretKey accessKey;
+    private final SecretKey refreshKey;
+
+    private JWTKeys(SecretKey accessKey, SecretKey refreshKey) {
+        this.accessKey = accessKey;
+        this.refreshKey = refreshKey;
+    }
+
+    public String getEncodedAccessKey() {
+        return encode(getAccessKey());
+    }
+
+    public String getEncodedRefreshKey() {
+        return encode(getRefreshKey());
+    }
+
+    public static JWTKeys of(String encodedAccessKey, String encodedRefreshKey) {
+        return new JWTKeys(decode(encodedAccessKey), decode(encodedRefreshKey));
+    }
+
+    public static String encode(SecretKey secretKey) {
+        byte[] rawData = secretKey.getEncoded();
+        return Base64.getEncoder().encodeToString(rawData);
+    }
+
+    public static SecretKey decode(String encodedKey) {
+        if (!StringUtils.hasText(encodedKey)) {
+            return null;
+        }
+        byte[] decodedKey = Base64.getDecoder().decode(encodedKey);
+        return new SecretKeySpec(decodedKey, 0, decodedKey.length, signatureAlgorithm.getJcaName());
+    }
+
+}

--- a/src/main/java/koreatech/in/domain/Auth/JWTKeys.java
+++ b/src/main/java/koreatech/in/domain/Auth/JWTKeys.java
@@ -1,16 +1,11 @@
 package koreatech.in.domain.Auth;
 
 
-import io.jsonwebtoken.SignatureAlgorithm;
-import java.util.Base64;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import lombok.Getter;
-import org.springframework.util.StringUtils;
 
 @Getter
 public class JWTKeys {
-    private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
     private final SecretKey accessKey;
     private final SecretKey refreshKey;
@@ -20,29 +15,8 @@ public class JWTKeys {
         this.refreshKey = refreshKey;
     }
 
-    public String getEncodedAccessKey() {
-        return encode(getAccessKey());
-    }
-
-    public String getEncodedRefreshKey() {
-        return encode(getRefreshKey());
-    }
-
-    public static JWTKeys of(String encodedAccessKey, String encodedRefreshKey) {
-        return new JWTKeys(decode(encodedAccessKey), decode(encodedRefreshKey));
-    }
-
-    public static String encode(SecretKey secretKey) {
-        byte[] rawData = secretKey.getEncoded();
-        return Base64.getEncoder().encodeToString(rawData);
-    }
-
-    public static SecretKey decode(String encodedKey) {
-        if (!StringUtils.hasText(encodedKey)) {
-            return null;
-        }
-        byte[] decodedKey = Base64.getDecoder().decode(encodedKey);
-        return new SecretKeySpec(decodedKey, 0, decodedKey.length, signatureAlgorithm.getJcaName());
+    public static JWTKeys of(SecretKey accessKey, SecretKey refreshKey) {
+        return new JWTKeys(accessKey, refreshKey);
     }
 
 }

--- a/src/main/java/koreatech/in/util/JwtTokenGenerator.java
+++ b/src/main/java/koreatech/in/util/JwtTokenGenerator.java
@@ -1,32 +1,63 @@
 package koreatech.in.util;
 
-import io.jsonwebtoken.*;
+import static koreatech.in.exception.ExceptionInformation.ACCESS_TOKEN_CHANGED;
+import static koreatech.in.exception.ExceptionInformation.ACCESS_TOKEN_EXPIRED;
+import static koreatech.in.exception.ExceptionInformation.BAD_ACCESS;
+
+import com.google.gson.JsonObject;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.util.JSON;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
-import koreatech.in.exception.BaseException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.util.StringUtils;
-
-import javax.annotation.PostConstruct;
-import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.Date;
-
-import static koreatech.in.exception.ExceptionInformation.*;
+import java.util.Optional;
+import javax.annotation.PostConstruct;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import koreatech.in.domain.Auth.JWTKeys;
+import koreatech.in.exception.BaseException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.util.StringUtils;
 
 public class JwtTokenGenerator {
+    private static final String ACCESS_KEY_FIELD_NAME = "access_key";
+    private static final String REFRESH_KEY_FIELD_NAME = "refresh_key";
+    private static final String SECRET_KEY_COLLECTION = "secret_key";
+
     @Autowired
     private StringRedisUtilStr stringRedisUtilStr;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
 
     @Value("${redis.key.login_prefix}")
     private String redisLoginTokenKeyPrefix;
 
     private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
-    private SecretKey key;
+    private SecretKey accessKey;
+
+    private JWTKeys jwtKeys;
+
+    public SecretKey getAccessKey() {
+        return this.jwtKeys.getAccessKey();
+    }
+
+    public SecretKey getRefreshKey() {
+        return this.jwtKeys.getRefreshKey();
+    }
 
     public static String convertSecretKeyToString(SecretKey secretKey) {
         byte[] rawData = secretKey.getEncoded();
@@ -44,26 +75,33 @@ public class JwtTokenGenerator {
     @PostConstruct
     public void keySetter() throws IOException {
         try {
-            key = convertStringToSecretKey(stringRedisUtilStr.getDataAsString("secretKey"));
-            if (key == null) {
-                key = Keys.secretKeyFor(signatureAlgorithm);
-                stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(key));
+            accessKey = convertStringToSecretKey(stringRedisUtilStr.getDataAsString("secretKey"));
+            if (accessKey == null) {
+                accessKey = Keys.secretKeyFor(signatureAlgorithm);
+                stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(accessKey));
             }
         } catch (IOException | IllegalArgumentException e) {
-            key = Keys.secretKeyFor(signatureAlgorithm);
-            stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(key));
+            accessKey = Keys.secretKeyFor(signatureAlgorithm);
+            stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(accessKey));
         }
+    }
+
+    @PostConstruct
+    public void KeySetterForV2() {
+        DBCollection secretKeyCollection = mongoTemplate.getCollection(SECRET_KEY_COLLECTION);
+
+        this.jwtKeys = enrichKeysAndSetDB(secretKeyCollection);
     }
 
     public String generate(int id) {
         Date exp = DateUtil.addHoursToJavaUtilDate(new Date(), 72);
-        return Jwts.builder().setSubject(String.valueOf(id)).setExpiration(exp).signWith(this.key).compact();
+        return Jwts.builder().setSubject(String.valueOf(id)).setExpiration(exp).signWith(getAccessKey()).compact();
     }
 
     public int me(String token) {
         try {
             Claims body = Jwts.parser()
-                    .setSigningKey(this.key)
+                    .setSigningKey(getAccessKey())
                     .parseClaimsJws(token)
                     .getBody();
 
@@ -84,7 +122,7 @@ public class JwtTokenGenerator {
 
     public Boolean isExpired(String token) {
         try {
-            Jwts.parser().setSigningKey(this.key).parseClaimsJws(token);
+            Jwts.parser().setSigningKey(getAccessKey()).parseClaimsJws(token);
             return false;
         } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
             throw new BaseException(BAD_ACCESS);
@@ -92,4 +130,99 @@ public class JwtTokenGenerator {
             return true;
         }
     }
+
+    private static String encode(SecretKey secretKey) {
+        byte[] rawData = secretKey.getEncoded();
+        return Base64.getEncoder().encodeToString(rawData);
+    }
+
+    private static SecretKey decode(String encodedKey) {
+        if (!StringUtils.hasText(encodedKey)) {
+            return null;
+        }
+        byte[] decodedKey = Base64.getDecoder().decode(encodedKey);
+        return new SecretKeySpec(decodedKey, 0, decodedKey.length, signatureAlgorithm.getJcaName());
+    }
+
+    private JWTKeys enrichKeysAndSetDB(DBCollection secretKeyCollection) {
+        Optional<DBObject> jwtKeysInDBOptional = Optional.ofNullable(secretKeyCollection.findOne());
+
+        if (!jwtKeysInDBOptional.isPresent()) {
+            return createAndInsertDB(secretKeyCollection);
+        }
+
+        DBObject jwtKeysInDB = jwtKeysInDBOptional.get();
+
+        if(!needAnyKeyUpdate(jwtKeysInDB)) {
+            return maintainKeysOnly(jwtKeysInDB);
+        }
+        return updateAndUpsertDB(secretKeyCollection, jwtKeysInDB);
+    }
+
+    private JWTKeys updateAndUpsertDB(DBCollection secretKeyCollection, DBObject jwtKeysInDB) {
+        JWTKeys enrichedJwtKeys = JWTKeys.of(
+                enrichKeyFor(jwtKeysInDB, ACCESS_KEY_FIELD_NAME),
+                enrichKeyFor(jwtKeysInDB, REFRESH_KEY_FIELD_NAME)
+        );
+
+        secretKeyCollection.update(new BasicDBObject(), toDBObjectWithEncode(enrichedJwtKeys), true, false);
+
+        return enrichedJwtKeys;
+    }
+
+    private JWTKeys maintainKeysOnly(DBObject jwtKeysInDB) {
+        String accessKey = getKeyFor(jwtKeysInDB, ACCESS_KEY_FIELD_NAME);
+        String refreshKey = getKeyFor(jwtKeysInDB, REFRESH_KEY_FIELD_NAME);
+
+        return JWTKeys.of(decode(accessKey), decode(refreshKey));
+    }
+
+    private JWTKeys createAndInsertDB(DBCollection secretKeyCollection) {
+        JWTKeys newJwtKeys = createKeys();
+        secretKeyCollection.insert(toDBObjectWithEncode(newJwtKeys));
+        return newJwtKeys;
+    }
+
+    private SecretKey enrichKeyFor(DBObject jwtKeysInDB, String keyFieldName) {
+        if(needKeyCreate(jwtKeysInDB, keyFieldName)) {
+            return Keys.secretKeyFor(signatureAlgorithm);
+        }
+
+        return decode(getKeyFor(jwtKeysInDB, ACCESS_KEY_FIELD_NAME));
+    }
+
+    private boolean needAnyKeyUpdate(DBObject jwtKeysInDB) {
+        return needKeyCreate(jwtKeysInDB, ACCESS_KEY_FIELD_NAME) || needKeyCreate(jwtKeysInDB, REFRESH_KEY_FIELD_NAME);
+    }
+
+    private Boolean needKeyCreate(DBObject jwtKeysInDB, String fieldName) {
+        if (!(jwtKeysInDB.containsField(fieldName))) {
+            return true;
+        }
+        Object fieldKey = jwtKeysInDB.get(fieldName);
+
+        if (!(fieldKey instanceof String)) {
+            return true;
+        }
+        return ((String) fieldKey).isEmpty();
+    }
+
+    private String getKeyFor(DBObject jwtKeysInDB, String fieldName) {
+        return (String) jwtKeysInDB.get(fieldName);
+    }
+
+    private JWTKeys createKeys() {
+        return JWTKeys.of(Keys.secretKeyFor(signatureAlgorithm),
+                Keys.secretKeyFor(signatureAlgorithm));
+    }
+
+    private DBObject toDBObjectWithEncode(JWTKeys jwtKeys) {
+        JsonObject encodedKeysJson = new JsonObject();
+
+        encodedKeysJson.addProperty(ACCESS_KEY_FIELD_NAME, encode(jwtKeys.getAccessKey()));
+        encodedKeysJson.addProperty(REFRESH_KEY_FIELD_NAME, encode(jwtKeys.getRefreshKey()));
+
+        return (DBObject) JSON.parse(encodedKeysJson.toString());
+    }
+
 }

--- a/src/main/java/koreatech/in/util/JwtTokenGenerator.java
+++ b/src/main/java/koreatech/in/util/JwtTokenGenerator.java
@@ -47,9 +47,31 @@ public class JwtTokenGenerator {
 
     private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
-    private SecretKey accessKey;
 
     private JWTKeys jwtKeys;
+
+    /*
+
+    private SecretKey accessKey;
+
+    public SecretKey getAccessKey() {
+        return accessKey;
+    }
+
+    @PostConstruct
+    public void keySetter() throws IOException {
+        try {
+            accessKey = convertStringToSecretKey(stringRedisUtilStr.getDataAsString("secretKey"));
+            if (accessKey == null) {
+                accessKey = Keys.secretKeyFor(signatureAlgorithm);
+                stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(accessKey));
+            }
+        } catch (IOException | IllegalArgumentException e) {
+            accessKey = Keys.secretKeyFor(signatureAlgorithm);
+            stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(accessKey));
+        }
+    }
+    */
 
     public SecretKey getAccessKey() {
         return this.jwtKeys.getAccessKey();
@@ -70,20 +92,6 @@ public class JwtTokenGenerator {
         }
         byte[] decodedKey = Base64.getDecoder().decode(encodedKey);
         return new SecretKeySpec(decodedKey, 0, decodedKey.length, signatureAlgorithm.getJcaName());
-    }
-
-    @PostConstruct
-    public void keySetter() throws IOException {
-        try {
-            accessKey = convertStringToSecretKey(stringRedisUtilStr.getDataAsString("secretKey"));
-            if (accessKey == null) {
-                accessKey = Keys.secretKeyFor(signatureAlgorithm);
-                stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(accessKey));
-            }
-        } catch (IOException | IllegalArgumentException e) {
-            accessKey = Keys.secretKeyFor(signatureAlgorithm);
-            stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(accessKey));
-        }
     }
 
     @PostConstruct

--- a/src/main/java/koreatech/in/util/JwtTokenGenerator.java
+++ b/src/main/java/koreatech/in/util/JwtTokenGenerator.java
@@ -72,15 +72,6 @@ public class JwtTokenGenerator {
             stringRedisUtilStr.setDataAsString("secretKey", convertSecretKeyToString(accessKey));
         }
     }
-    */
-
-    public SecretKey getAccessKey() {
-        return this.jwtKeys.getAccessKey();
-    }
-
-    public SecretKey getRefreshKey() {
-        return this.jwtKeys.getRefreshKey();
-    }
 
     public static String convertSecretKeyToString(SecretKey secretKey) {
         byte[] rawData = secretKey.getEncoded();
@@ -93,6 +84,16 @@ public class JwtTokenGenerator {
         }
         byte[] decodedKey = Base64.getDecoder().decode(encodedKey);
         return new SecretKeySpec(decodedKey, 0, decodedKey.length, signatureAlgorithm.getJcaName());
+    }
+
+    */
+
+    public SecretKey getAccessKey() {
+        return this.jwtKeys.getAccessKey();
+    }
+
+    public SecretKey getRefreshKey() {
+        return this.jwtKeys.getRefreshKey();
     }
 
     @PostConstruct


### PR DESCRIPTION
### as-is
- 하나의 인메모리 저장소에 토큰과 비밀 키를 모두 저장
### to-be
- 토큰 연장을 위한 새로운  비밀 키 도입
- 비밀 키 보관은 다른 DB를 이용하도록 변경

**상세 로직**
1. 기존 인메모리 저장소에 있는 데이터가 있다면 가져온다.
2. DB에 데이터가 있다면 가져온다.
3. 1,2 모두 없다면 새로 만든다.
4. DB에 저장한다.
5. 필드에 저장한다.

*기존 키, 새로운 키 모두 상세 로직으로 동작한다.