### PR TITLE
Refactor: 메뉴 리스트 조회 응답 스키마 변경

### DIFF
--- a/src/main/java/koreatech/in/dto/admin/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/admin/shop/response/AllMenusOfShopResponse.java
@@ -2,11 +2,14 @@ package koreatech.in.dto.admin.shop.response;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import koreatech.in.domain.Shop.ShopCategory;
 import koreatech.in.domain.Shop.ShopMenuProfile;
 import koreatech.in.mapstruct.admin.shop.AdminShopMenuConverter;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,8 +19,21 @@ public class AllMenusOfShopResponse {
     @ApiModelProperty(notes = "개수", example = "20", required = true)
     private Integer count;
 
-    @ApiModelProperty(notes = "전체 메뉴 리스트", required = true)
-    private List<Menu> menus;
+    @ApiModelProperty(notes = "카테고리 별로 분류된 소속 메뉴 리스트", required = true)
+    private List<Category> menu_categories;
+
+    @Getter @Builder
+    @ApiModel("CategoryModel_2")
+    public static class Category {
+        @ApiModelProperty(notes = "카테고리 id", example = "1", required = true)
+        private Integer id;
+
+        @ApiModelProperty(notes = "카테고리 이름", example = "중식", required = true)
+        private String name;
+
+        @ApiModelProperty(notes = "해당 상점의 모든 메뉴 리스트", required = true)
+        private List<Menu> menus;
+    }
 
     @Getter @Builder
     @ApiModel("Menu_1")
@@ -31,37 +47,64 @@ public class AllMenusOfShopResponse {
         @ApiModelProperty(notes = "숨김 여부", example = "false", required = true)
         private Boolean is_hidden;
 
-        @ApiModelProperty(notes = "단일 메뉴 여부", example = "true", required = true)
+        @ApiModelProperty(notes = "단일 메뉴 여부 \n" +
+                "- true: 단일 메뉴 \n" +
+                "- false: 옵션이 있는 메뉴", example = "false", required = true)
         private Boolean is_single;
 
         @ApiModelProperty(notes = "단일 메뉴일때(is_single이 true일때)의 가격", example = "10000")
         private Integer single_price;
 
-        @ApiModelProperty(notes = "옵션이 있는 메뉴일때(is_single이 false일때)의 가격")
+        @ApiModelProperty(notes = "옵션이 있는 메뉴일때(is_single이 false일때)의 옵션에 따른 가격 리스트")
         private List<OptionPrice> option_prices;
 
-        @ApiModelProperty(notes = "소속되어 있는 메뉴 카테고리 고유 id 리스트", required = true)
-        private List<Integer> category_ids;
+        @ApiModelProperty(notes = "설명", example = "저희 식당의 대표 메뉴 탕수육입니다.")
+        private String description;
+
+        @ApiModelProperty(notes = "이미지 URL 리스트")
+        private List<String> image_urls;
 
         @Getter @Builder
         @ApiModel("OptionPrice_2")
         public static class OptionPrice {
-            @ApiModelProperty(notes = "옵션명", example = "소", required = true)
+            @ApiModelProperty(notes = "옵션명", example = "대", required = true)
             private String option;
 
-            @ApiModelProperty(notes = "옵션에 대한 가격", example = "10000", required = true)
+            @ApiModelProperty(notes = "가격", example = "26000", required = true)
             private Integer price;
         }
     }
 
-    public static AllMenusOfShopResponse from(List<ShopMenuProfile> shopMenuProfiles) {
+    public static AllMenusOfShopResponse from(List<ShopMenuProfile> shopMenuProfiles, List<ShopCategory> categoryNames) {
+        List<Category> category = new ArrayList<>();
+        List<Integer> categoryIds = shopMenuProfiles.stream()
+                .map(ShopMenuProfile::getCategory_ids)
+                .flatMap(Collection::stream)
+                .distinct()
+                .sorted()
+                .collect(Collectors.toList());
+        for (int i = 0; i < categoryIds.size(); i++) {
+            int categoryIndex = categoryIds.get(i);
+            category.add(
+                    AllMenusOfShopResponse.Category.builder()
+                            .id(categoryIndex)
+                            .name(
+                                    categoryNames.stream()
+                                            .filter(categoryName -> categoryName.getId().equals(categoryIndex))
+                                            .collect(Collectors.toList()).get(0).getName()
+                            )
+                            .menus(
+                                    shopMenuProfiles.stream()
+                                            .filter(menuProfile -> menuProfile.getCategory_ids().contains(categoryIndex))
+                                            .map(AdminShopMenuConverter.INSTANCE::toAllMenusOfShopResponse$Menu)
+                                            .collect(Collectors.toList())
+                            )
+                            .build()
+            );
+        }
         return AllMenusOfShopResponse.builder()
                 .count(shopMenuProfiles.size())
-                .menus(
-                        shopMenuProfiles.stream()
-                                .map(AdminShopMenuConverter.INSTANCE::toAllMenusOfShopResponse$Menu)
-                                .collect(Collectors.toList())
-                )
+                .menu_categories(category)
                 .build();
     }
 }

--- a/src/main/java/koreatech/in/dto/admin/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/admin/shop/response/AllMenusOfShopResponse.java
@@ -1,5 +1,10 @@
 package koreatech.in.dto.admin.shop.response;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import koreatech.in.domain.Shop.ShopCategory;
@@ -7,11 +12,6 @@ import koreatech.in.domain.Shop.ShopMenuProfile;
 import koreatech.in.mapstruct.admin.shop.AdminShopMenuConverter;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter @Builder
 @ApiModel("AdminAllMenusOfShopResponse")
@@ -89,9 +89,11 @@ public class AllMenusOfShopResponse {
                     AllMenusOfShopResponse.Category.builder()
                             .id(categoryIndex)
                             .name(
-                                    categoryNames.stream()
-                                            .filter(categoryName -> categoryName.getId().equals(categoryIndex))
-                                            .collect(Collectors.toList()).get(0).getName()
+                                categoryNames.stream()
+                                    .filter(categoryName -> categoryName.getId().equals(categoryIndex))
+                                    .findFirst()
+                                    .orElse(ShopCategory.builder().name("미분류").build())
+                                    .getName()
                             )
                             .menus(
                                     shopMenuProfiles.stream()

--- a/src/main/java/koreatech/in/dto/admin/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/admin/shop/response/AllMenusOfShopResponse.java
@@ -75,7 +75,7 @@ public class AllMenusOfShopResponse {
         }
     }
 
-    public static AllMenusOfShopResponse from(List<ShopMenuProfile> shopMenuProfiles, List<ShopCategory> categoryNames) {
+    public static AllMenusOfShopResponse of(List<ShopMenuProfile> shopMenuProfiles, List<ShopCategory> categoryNames) {
         List<Category> category = new ArrayList<>();
         List<Integer> categoryIds = shopMenuProfiles.stream()
                 .map(ShopMenuProfile::getCategory_ids)

--- a/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
@@ -78,8 +78,8 @@ public class AllMenusOfShopResponse {
         List<Category> category = new ArrayList<>();
         List<Integer> categoryIds = shopMenuProfiles.stream()
                 .map(ShopMenuProfile::getCategory_ids)
-                .distinct()
                 .flatMap(Collection::stream)
+                .distinct()
                 .sorted()
                 .collect(Collectors.toList());
         for (int i = 0; i < categoryIds.size(); i++) {

--- a/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
@@ -90,7 +90,9 @@ public class AllMenusOfShopResponse {
                             .name(
                                     categoryNames.stream()
                                             .filter(categoryName -> categoryName.getId().equals(categoryIndex))
-                                            .collect(Collectors.toList()).get(0).getName()
+                                            .findFirst()
+                                            .orElse(ShopCategory.builder().name("미분류").build())
+                                            .getName()
                             )
                             .menus(
                                     shopMenuProfiles.stream()

--- a/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
@@ -74,7 +74,7 @@ public class AllMenusOfShopResponse {
         }
     }
 
-    public static AllMenusOfShopResponse from(List<ShopMenuProfile> shopMenuProfiles, List<ShopCategory> categoryNames) {
+    public static AllMenusOfShopResponse of(List<ShopMenuProfile> shopMenuProfiles, List<ShopCategory> categoryNames) {
         List<Category> category = new ArrayList<>();
         List<Integer> categoryIds = shopMenuProfiles.stream()
                 .map(ShopMenuProfile::getCategory_ids)

--- a/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
@@ -83,25 +83,23 @@ public class AllMenusOfShopResponse {
                 .sorted()
                 .collect(Collectors.toList());
         for (int i = 0; i < categoryIds.size(); i++) {
-            for (int j = 0; j < shopMenuProfiles.get(i).getCategory_ids().size(); j++) {
-                int categoryIndex = categoryIds.get(i);
-                category.add(
-                        Category.builder()
-                                .id(categoryIndex)
-                                .name(
-                                        categoryNames.stream()
-                                                .filter(categoryName -> categoryName.getId().equals(categoryIndex))
-                                                .collect(Collectors.toList()).get(0).getName()
-                                )
-                                .menus(
-                                        shopMenuProfiles.stream()
-                                                .filter(menuProfile -> menuProfile.getCategory_ids().contains(categoryIndex))
-                                                .map(ShopMenuConverter.INSTANCE::toAllMenusOfShopResponse$Menu)
-                                                .collect(Collectors.toList())
-                                )
-                                .build()
-                );
-            }
+            int categoryIndex = categoryIds.get(i);
+            category.add(
+                    Category.builder()
+                            .id(categoryIndex)
+                            .name(
+                                    categoryNames.stream()
+                                            .filter(categoryName -> categoryName.getId().equals(categoryIndex))
+                                            .collect(Collectors.toList()).get(0).getName()
+                            )
+                            .menus(
+                                    shopMenuProfiles.stream()
+                                            .filter(menuProfile -> menuProfile.getCategory_ids().contains(categoryIndex))
+                                            .map(ShopMenuConverter.INSTANCE::toAllMenusOfShopResponse$Menu)
+                                            .collect(Collectors.toList())
+                            )
+                            .build()
+            );
         }
         return AllMenusOfShopResponse.builder()
                 .count(shopMenuProfiles.size())

--- a/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/response/AllMenusOfShopResponse.java
@@ -22,7 +22,7 @@ public class AllMenusOfShopResponse {
     private List<Category> menu_categories;
 
     @Getter @Builder
-    @ApiModel("CategoryModel")
+    @ApiModel("CategoryModel_1")
     public static class Category {
         @ApiModelProperty(notes = "카테고리 id", example = "1", required = true)
         private Integer id;

--- a/src/main/java/koreatech/in/repository/ShopMapper.java
+++ b/src/main/java/koreatech/in/repository/ShopMapper.java
@@ -1,7 +1,7 @@
 package koreatech.in.repository;
 
 import koreatech.in.domain.Shop.*;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -49,6 +49,8 @@ public interface ShopMapper {
     List<ShopMenuCategory> getMenuCategoriesByShopId(@Param("shopId") Integer shopId);
 
     ShopMenuCategory getMenuCategoryById(@Param("id") Integer id);
+
+    List<ShopCategory> getMenuCategoryNamesByShopId(@Param("shopId") Integer id);
 
     List<ShopMenu> getMenusUsingCategoryByMenuCategoryId(@Param("menuCategoryId") Integer menuCategoryId);
 

--- a/src/main/java/koreatech/in/repository/admin/AdminShopMapper.java
+++ b/src/main/java/koreatech/in/repository/admin/AdminShopMapper.java
@@ -56,6 +56,8 @@ public interface AdminShopMapper {
 
     List<ShopMenuCategoryMap> getMenuCategoryMapsByMenuId(@Param("menuId") Integer menuId);
 
+    List<ShopCategory> getMenuCategoryNamesByShopId(@Param("shopId") Integer shopId);
+
     void deleteMenuCategoryMaps(@Param("menuCategoryMaps") List<ShopMenuCategoryMap> menuCategoryMaps);
 
     List<ShopMenuImage> getMenuImagesByMenuId(@Param("menuId") Integer menuId);

--- a/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -277,7 +276,7 @@ public class OwnerShopServiceImpl implements OwnerShopService {
         menuProfiles.forEach(ShopMenuProfile::decideWhetherSingleOrNot);
         List<ShopCategory> categoryNames = shopMapper.getMenuCategoryNamesByShopId(shopId);
 
-        return AllMenusOfShopResponse.from(menuProfiles, categoryNames);
+        return AllMenusOfShopResponse.of(menuProfiles, categoryNames);
     }
 
     @Override

--- a/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -274,8 +275,9 @@ public class OwnerShopServiceImpl implements OwnerShopService {
 
         List<ShopMenuProfile> menuProfiles = shopMapper.getMenuProfilesByShopId(shopId);
         menuProfiles.forEach(ShopMenuProfile::decideWhetherSingleOrNot);
+        List<ShopCategory> categoryNames = shopMapper.getMenuCategoryNamesByShopId(shopId);
 
-        return AllMenusOfShopResponse.from(menuProfiles);
+        return AllMenusOfShopResponse.from(menuProfiles, categoryNames);
     }
 
     @Override

--- a/src/main/java/koreatech/in/service/ShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/ShopServiceImpl.java
@@ -1,6 +1,9 @@
 package koreatech.in.service;
 
-import koreatech.in.domain.Shop.*;
+import koreatech.in.domain.Shop.ShopCategory;
+import koreatech.in.domain.Shop.ShopMenuCategory;
+import koreatech.in.domain.Shop.ShopMenuProfile;
+import koreatech.in.domain.Shop.ShopProfile;
 import koreatech.in.dto.normal.shop.response.*;
 import koreatech.in.exception.BaseException;
 import koreatech.in.mapstruct.normal.shop.ShopConverter;
@@ -10,10 +13,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static koreatech.in.exception.ExceptionInformation.*;
+import static koreatech.in.exception.ExceptionInformation.SHOP_MENU_NOT_FOUND;
+import static koreatech.in.exception.ExceptionInformation.SHOP_NOT_FOUND;
 
 @Service("shopService")
 @Transactional
@@ -57,8 +62,9 @@ public class ShopServiceImpl implements ShopService {
         menuProfiles.forEach(ShopMenuProfile::decideWhetherSingleOrNot);
 
         List<ShopMenuProfile> unhiddenMenuProfiles = getUnhiddenMenuProfilesBy(menuProfiles);
+        List<ShopCategory> categoryNames = shopMapper.getMenuCategoryNamesByShopId(shopId);
 
-        return AllMenusOfShopResponse.from(unhiddenMenuProfiles);
+        return AllMenusOfShopResponse.from(unhiddenMenuProfiles, categoryNames);
     }
 
     private List<ShopMenuProfile> getUnhiddenMenuProfilesBy(List<ShopMenuProfile> menuProfiles) {

--- a/src/main/java/koreatech/in/service/ShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/ShopServiceImpl.java
@@ -64,7 +64,7 @@ public class ShopServiceImpl implements ShopService {
         List<ShopMenuProfile> unhiddenMenuProfiles = getUnhiddenMenuProfilesBy(menuProfiles);
         List<ShopCategory> categoryNames = shopMapper.getMenuCategoryNamesByShopId(shopId);
 
-        return AllMenusOfShopResponse.from(unhiddenMenuProfiles, categoryNames);
+        return AllMenusOfShopResponse.of(unhiddenMenuProfiles, categoryNames);
     }
 
     private List<ShopMenuProfile> getUnhiddenMenuProfilesBy(List<ShopMenuProfile> menuProfiles) {

--- a/src/main/java/koreatech/in/service/admin/AdminShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminShopServiceImpl.java
@@ -424,8 +424,9 @@ public class AdminShopServiceImpl implements AdminShopService {
 
         List<ShopMenuProfile> menuProfilesOfShop = adminShopMapper.getMenuProfilesByShopId(shopId);
         menuProfilesOfShop.forEach(ShopMenuProfile::decideWhetherSingleOrNot);
+        List<ShopCategory> categoryNames = adminShopMapper.getMenuCategoryNamesByShopId(shopId);
 
-        return AllMenusOfShopResponse.from(menuProfilesOfShop);
+        return AllMenusOfShopResponse.from(menuProfilesOfShop, categoryNames);
     }
 
     @Override

--- a/src/main/java/koreatech/in/service/admin/AdminShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminShopServiceImpl.java
@@ -426,7 +426,7 @@ public class AdminShopServiceImpl implements AdminShopService {
         menuProfilesOfShop.forEach(ShopMenuProfile::decideWhetherSingleOrNot);
         List<ShopCategory> categoryNames = adminShopMapper.getMenuCategoryNamesByShopId(shopId);
 
-        return AllMenusOfShopResponse.from(menuProfilesOfShop, categoryNames);
+        return AllMenusOfShopResponse.of(menuProfilesOfShop, categoryNames);
     }
 
     @Override

--- a/src/main/resources/mapper/admin/AdminShopMapper.xml
+++ b/src/main/resources/mapper/admin/AdminShopMapper.xml
@@ -465,6 +465,22 @@
         WHERE `shop_menu_id` = #{menuId}
     </select>
 
+    <select id="getMenuCategoryNamesByShopId" parameterType="integer" resultType="koreatech.in.domain.Shop.ShopCategory">
+        SELECT DISTINCT `t1`.`id` AS `id`,
+                        `t1`.`name` AS `name`
+        FROM (
+                 SELECT *
+                 FROM `koin`.`shop_menu_categories`
+                 WHERE
+                     `shop_id` = #{shopId}
+                   AND `is_deleted` = 0
+             ) `t1`
+                 LEFT JOIN `koin`.`shop_menus` `t2`
+                           ON `t1`.`shop_id` = `t2`.`shop_id`
+                 LEFT JOIN `koin`.`shop_menu_category_map` `t3`
+                           ON `t1`.`id` = `t3`.`shop_menu_category_id`
+    </select>
+
     <delete id="deleteMenuCategoryMaps" parameterType="list">
         <foreach collection="menuCategoryMaps" item="item" separator=";">
             DELETE

--- a/src/main/resources/mapper/normal/ShopMapper.xml
+++ b/src/main/resources/mapper/normal/ShopMapper.xml
@@ -419,9 +419,9 @@
             AND `is_deleted` = 0
     </select>
 
-    <select id="getMenuCategoryNamesByShopId" parameterType="integer" resultMap="ShopMenuCategoryName">
-        SELECT DISTINCT `t1`.`id` AS `shop_menu_categories.id`,
-                        `t1`.`name` AS `shop_menu_categories.name`
+    <select id="getMenuCategoryNamesByShopId" parameterType="integer" resultType="koreatech.in.domain.Shop.ShopCategory">
+        SELECT DISTINCT `t1`.`id` AS `id`,
+                        `t1`.`name` AS `name`
         FROM (
                  SELECT *
                  FROM `koin`.`shop_menu_categories`
@@ -700,10 +700,5 @@
         <collection property="category_ids" javaType="list" ofType="integer">
             <id property="id" column="shop_menu_categories.id"/>
         </collection>
-    </resultMap>
-    
-    <resultMap id="ShopMenuCategoryName" type="koreatech.in.domain.Shop.ShopCategory">
-        <id property="id" column="shop_menu_categories.id"/>
-        <result property="name" column="shop_menu_categories.name"/>
     </resultMap>
 </mapper>

--- a/src/main/resources/mapper/normal/ShopMapper.xml
+++ b/src/main/resources/mapper/normal/ShopMapper.xml
@@ -419,6 +419,22 @@
             AND `is_deleted` = 0
     </select>
 
+    <select id="getMenuCategoryNamesByShopId" parameterType="integer" resultMap="ShopMenuCategoryName">
+        SELECT DISTINCT `t1`.`id` AS `shop_menu_categories.id`,
+                        `t1`.`name` AS `shop_menu_categories.name`
+        FROM (
+                 SELECT *
+                 FROM `koin`.`shop_menu_categories`
+                 WHERE
+                     `shop_id` = #{shopId}
+                   AND `is_deleted` = 0
+             ) `t1`
+                 LEFT JOIN `koin`.`shop_menus` `t2`
+                           ON `t1`.`shop_id` = `t2`.`shop_id`
+                 LEFT JOIN `koin`.`shop_menu_category_map` `t3`
+                           ON `t1`.`id` = `t3`.`shop_menu_category_id`
+    </select>
+
     <select id="getMenusUsingCategoryByMenuCategoryId" parameterType="integer" resultType="koreatech.in.domain.Shop.ShopMenu">
         SELECT *
         FROM `koin`.`shop_menus`
@@ -684,5 +700,10 @@
         <collection property="category_ids" javaType="list" ofType="integer">
             <id property="id" column="shop_menu_categories.id"/>
         </collection>
+    </resultMap>
+    
+    <resultMap id="ShopMenuCategoryName" type="koreatech.in.domain.Shop.ShopCategory">
+        <id property="id" column="shop_menu_categories.id"/>
+        <result property="name" column="shop_menu_categories.name"/>
     </resultMap>
 </mapper>


### PR DESCRIPTION
## ▶ Request
### Content
<!-- 이슈 번호가 있으면 적어주세요. e.g. #13 -->
#209 
### as-is
메뉴 리스트 조회 시 응답 스키마의 구조: 각 menu가 category_id를 리스트로 보유
```java
{
  "menus": [
    {
      (메뉴 정보),
      "category_ids": [
        (카테고리 id)
      ]
    }
}
```

### to-be
메뉴 리스트 조회 시 응답 스키마의 구조: 각 category별로 포함되는 menu 정보를 보유
기존 구조에서 추가적으로 카테고리명을 함께 반환
```java
{
  "categories": [
    {
      "id": (카테고리 id),
      "name": "카테고리명",
      "menus": [
        {
          (메뉴 정보)
        }
  ]
]
```

### 세부 구현 내용
- AllMenusOfShopResponse DTO 구조 변경 (Admin)
    - 사용처
        - /admin/shops/{id}/menus
- AllMenusOfShopResponse DTO 구조 변경 (Normal)
    - 사용처
        - /shops/{id}/menus
        - /owner/shops/{id}/menus
- 위의 두 DTO는 내부적으로 서로 다르지만 현재 동일한 구조를 지니고 있음
- 조회를 시도한 상점의 총 메뉴 개수를 반환 (기존 form 유지를 위해 제공)
    - response되는 메뉴의 총 개수는 아님
        - 단일 메뉴가 복수의 메뉴 카테고리 보유 시 여러 카테고리에서 반환됨

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot
![image](https://github.com/BCSDLab/KOIN_API/assets/21010656/19f39311-6de0-459b-837f-01311fc8c1f5)
![image](https://github.com/BCSDLab/KOIN_API/assets/21010656/e15a1370-5d66-4275-9392-ec9ac5dac0f4)
![image](https://github.com/BCSDLab/KOIN_API/assets/21010656/99b6143d-694b-417d-a600-79c18b425048)


## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] 총 메뉴 개수(count)가 정상적으로 반환되는지 확인
- [x] 각 카테고리의 id와 함께 name이 정상적으로 반환되는지 확인
- [x] 단일 메뉴가 복수의 메뉴 카테고리 보유 시 정상적으로 반환되는지 확인
- [x] 점주용 상점 메뉴 조회 API 호출 시 자신의 상점이 아니라면 403 error(권한 없음)가 발생하는지 확인
    - 일반 상점용 상점 메뉴 조회 API 호출 시 자신의 상점 유무와 관계없이 동작 확인
