### PR TITLE
Fix: refresh API 인가 에러 수정

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -90,6 +90,7 @@ public class UserController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @AuthExcept
     @ApiOperation(
             value = "액세스 토큰 재발급"
             , notes = "- 사용자 권한 허용"

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -9,7 +9,6 @@ import io.swagger.annotations.Authorization;
 import java.util.List;
 import java.util.Map;
 import javax.validation.Valid;
-import io.swagger.models.auth.In;
 import koreatech.in.annotation.ApiOff;
 import koreatech.in.annotation.Auth;
 import koreatech.in.annotation.AuthExcept;
@@ -29,11 +28,9 @@ import koreatech.in.dto.admin.user.request.NewOwnersCondition;
 import koreatech.in.dto.admin.user.response.LoginResponse;
 import koreatech.in.dto.admin.user.response.NewOwnersResponse;
 import koreatech.in.dto.admin.user.response.OwnerResponse;
-import koreatech.in.dto.admin.user.student.response.StudentResponse;
 import koreatech.in.dto.admin.user.student.request.StudentUpdateRequest;
 import koreatech.in.dto.admin.user.student.response.StudentResponse;
 import koreatech.in.dto.admin.user.student.response.StudentUpdateResponse;
-import koreatech.in.dto.normal.user.request.UpdateUserRequest;
 import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.service.admin.AdminUserService;
@@ -89,6 +86,7 @@ public class AdminUserController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @AuthExcept
     @ApiOperation(
             value = "액세스 토큰 재발급"
             , notes = "- 어드민 권한만 허용"
@@ -108,7 +106,7 @@ public class AdminUserController {
         } catch (Exception exception) {
             throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
         }
-
+        //TODO Refresh Token을 통해 Admin인지 판단.
         TokenRefreshResponse tokenRefreshResponse = adminUserService.refresh(request);
         return new ResponseEntity<>(tokenRefreshResponse, HttpStatus.CREATED);
     }

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -388,21 +388,11 @@ public class UserServiceImpl implements UserService, UserDetailsService {
     @Override
     public TokenRefreshResponse refresh(TokenRefreshRequest request) {
         RefreshToken refreshToken = AuthConverter.INSTANCE.toToken(request);
-        User userInHeader = jwtValidator.validate();
 
         Integer tokenUserId = userRefreshJwtGenerator.getFromToken(refreshToken.getToken());
-        validateEqualUser(userInHeader, tokenUserId);
 
         String newToken = userAccessJwtGenerator.generateToken(tokenUserId);
-
-
         return AuthConverter.INSTANCE.toTokenRefreshResponse(newToken);
-    }
-
-    private void validateEqualUser(User userInHeader, Integer tokenUserId) {
-        if(!userInHeader.hasSameId(tokenUserId)) {
-            throw new BaseException(ExceptionInformation.BAD_ACCESS);
-        }
     }
 
     private User getUserByEmail(String email) {

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -2,21 +2,18 @@ package koreatech.in.service.admin;
 
 import static koreatech.in.domain.DomainToMap.domainToMap;
 import static koreatech.in.exception.ExceptionInformation.AUTHENTICATED_USER;
+import static koreatech.in.exception.ExceptionInformation.FORBIDDEN;
+import static koreatech.in.exception.ExceptionInformation.GENDER_INVALID;
 import static koreatech.in.exception.ExceptionInformation.INQUIRED_USER_NOT_FOUND;
+import static koreatech.in.exception.ExceptionInformation.NICKNAME_DUPLICATE;
 import static koreatech.in.exception.ExceptionInformation.NOT_OWNER;
 import static koreatech.in.exception.ExceptionInformation.NOT_STUDENT;
 import static koreatech.in.exception.ExceptionInformation.PAGE_NOT_FOUND;
 import static koreatech.in.exception.ExceptionInformation.PASSWORD_DIFFERENT;
 import static koreatech.in.exception.ExceptionInformation.SHOP_NOT_FOUND;
-import static koreatech.in.exception.ExceptionInformation.USER_NOT_FOUND;
-
-import java.sql.SQLException;
-
-import static koreatech.in.exception.ExceptionInformation.USER_NOT_FOUND;
-import static koreatech.in.exception.ExceptionInformation.STUDENT_NUMBER_INVALID;
 import static koreatech.in.exception.ExceptionInformation.STUDENT_MAJOR_INVALID;
-import static koreatech.in.exception.ExceptionInformation.GENDER_INVALID;
-import static koreatech.in.exception.ExceptionInformation.NICKNAME_DUPLICATE;
+import static koreatech.in.exception.ExceptionInformation.STUDENT_NUMBER_INVALID;
+import static koreatech.in.exception.ExceptionInformation.USER_NOT_FOUND;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -25,14 +22,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-
 import koreatech.in.domain.Auth.LoginResult;
 import koreatech.in.domain.Auth.RefreshToken;
 import koreatech.in.domain.Authority;
 import koreatech.in.domain.Criteria.UserCriteria;
 import koreatech.in.domain.ErrorMessage;
-import koreatech.in.domain.Shop.Shop;
 import koreatech.in.domain.User.EmailAddress;
 import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.UserCode;
@@ -50,7 +44,6 @@ import koreatech.in.dto.admin.user.student.response.StudentResponse;
 import koreatech.in.dto.admin.user.student.response.StudentUpdateResponse;
 import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ConflictException;
-import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.exception.NotFoundException;
 import koreatech.in.exception.PreconditionFailedException;
 import koreatech.in.mapstruct.admin.auto.AuthConverter;
@@ -69,8 +62,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static koreatech.in.domain.DomainToMap.domainToMap;
 
 @Service
 @Transactional
@@ -512,21 +503,16 @@ public class AdminUserServiceImpl implements AdminUserService {
     public TokenRefreshResponse refresh(TokenRefreshRequest request) {
         RefreshToken refreshToken = AuthConverter.INSTANCE.toToken(request);
 
-        User userInHeader = jwtValidator.validate();
-
-        //어드민만 접근가능하므로, 어드민임을 다시 검증할 필요는 없다.
-
         Integer tokenUserId = userRefreshJwtGenerator.getFromToken(refreshToken.getToken());
-        validateEqualUser(userInHeader, tokenUserId);
+        validateAdmin(tokenUserId);
 
         String newToken = userAccessJwtGenerator.generateToken(tokenUserId);
         return AuthConverter.INSTANCE.toTokenRefreshResponse(newToken);
     }
 
-    private void validateEqualUser(User userInHeader, Integer tokenUserId) {
-        if(!userInHeader.hasSameId(tokenUserId)) {
-            throw new BaseException(ExceptionInformation.BAD_ACCESS);
-        }
+    private void validateAdmin(Integer tokenUserId) {
+        Optional.ofNullable(authorityMapper.getAuthorityByUserId(tokenUserId))
+                .orElseThrow(() -> new BaseException(FORBIDDEN));
     }
 
     private void deleteRefreshTokenInDB(Integer userId) {

--- a/src/main/java/koreatech/in/util/jwt/UserRefreshJwtGenerator.java
+++ b/src/main/java/koreatech/in/util/jwt/UserRefreshJwtGenerator.java
@@ -6,6 +6,8 @@ import io.jsonwebtoken.Jwts;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.repository.AuthenticationMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -44,14 +46,12 @@ public class UserRefreshJwtGenerator extends AbstractJwtGenerator<Integer> {
     protected void validateData(String token,  Integer data) {
         try {
             String tokenInRedis = redisAuthenticationMapper.getRefreshToken(data);
-            if (token.equals(tokenInRedis)) {
-                return;
+            if (!token.equals(tokenInRedis)) {
+                throw new BaseException(ExceptionInformation.FORBIDDEN);
             }
         } catch (IOException e) {
             throw new ExpiredJwtException(null, null, null, e);
-
         }
-        throw new ExpiredJwtException(null, null, null);
     }
 
     @Override


### PR DESCRIPTION
## ▶ Request
### Content
`/Refresh` 요청시 Access Token이 필요한 버그 수정
### as-is

### to-be


## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot
API 변경 없음.

## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] AccessToken 없이 두 API 모두 `/refresh` 동작
- [x] admin의 경우 요청한 리프레시 토큰이 어드민의 것인 경우에만 동작
