### PR TITLE
Refactor: 일부 API, 필드 숨김 처리

### DIFF
--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -205,6 +205,7 @@ public class UserController {
     }
 
     @ApiOff
+    @ApiIgnore
     @ParamValid
     @Auth(role = Auth.Role.OWNER)
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})

--- a/src/main/java/koreatech/in/controller/UserController.java
+++ b/src/main/java/koreatech/in/controller/UserController.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import koreatech.in.annotation.ApiOff;
 import koreatech.in.annotation.Auth;
 import koreatech.in.annotation.AuthExcept;
 import koreatech.in.annotation.ParamValid;
@@ -203,6 +204,7 @@ public class UserController {
         return new ResponseEntity<>(studentResponse, HttpStatus.CREATED);
     }
 
+    @ApiOff
     @ParamValid
     @Auth(role = Auth.Role.OWNER)
     @ApiOperation(value = "", authorizations = {@Authorization(value="Authorization")})

--- a/src/main/java/koreatech/in/domain/BokDuck/Land.java
+++ b/src/main/java/koreatech/in/domain/BokDuck/Land.java
@@ -1,6 +1,7 @@
 package koreatech.in.domain.BokDuck;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.gson.Gson;
 import io.swagger.annotations.ApiModelProperty;
 import koreatech.in.dto.admin.land.request.UpdateLandRequest;
@@ -218,6 +219,7 @@ public class Land {
         return this.id.equals(id);
     }
 
+    @JsonIgnore
     public boolean isSoftDeleted() {
         if (this.is_deleted == null) {
             return false;

--- a/src/main/java/koreatech/in/domain/DomainToMap.java
+++ b/src/main/java/koreatech/in/domain/DomainToMap.java
@@ -1,7 +1,6 @@
 package koreatech.in.domain;
 
-import org.apache.commons.lang.StringUtils;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
@@ -11,6 +10,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import koreatech.in.domain.BokDuck.Land;
 
 public class DomainToMap {
 
@@ -43,6 +43,11 @@ public class DomainToMap {
         BeanInfo info = Introspector.getBeanInfo(vo.getClass());
         for (PropertyDescriptor pd : info.getPropertyDescriptors()) {
             Method reader = pd.getReadMethod();
+
+            if (ignoredMethod(vo, reader)) {
+                continue;
+            }
+
             if (reader != null) {
                 if(arrExceptKeys != null && arrExceptKeys.length > 0 && isContain(arrExceptKeys, pd.getName())) continue;
                 if(!containNull && reader.invoke(vo) == null) continue;
@@ -57,6 +62,12 @@ public class DomainToMap {
         }
         return result;
     }
+
+    //Json Ignore이 달린 메서드들을 예외처리 함. (부수효과를 대비하여 Land의 경우만 처리함.)
+    private static boolean ignoredMethod(Object vo, Method reader) {
+        return vo instanceof Land && reader.isAnnotationPresent(JsonIgnore.class);
+    }
+
     public static Map<String, Object> domainToMapWithExcept(Object vo, String[] arrExceptKeys) throws Exception {
         return domainToMapWithExcept(vo, arrExceptKeys, true);
     }

--- a/src/main/java/koreatech/in/domain/Homepage/Member.java
+++ b/src/main/java/koreatech/in/domain/Homepage/Member.java
@@ -1,6 +1,7 @@
 package koreatech.in.domain.Homepage;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModelProperty;
 import koreatech.in.annotation.ValidationGroups;
 import koreatech.in.dto.admin.member.request.UpdateMemberRequest;
@@ -61,6 +62,7 @@ public class Member {
         this.image_url = request.getImage_url();
     }
 
+    @JsonIgnore
     public boolean isSoftDeleted() {
         if (this.is_deleted == null) {
             return false;

--- a/src/main/java/koreatech/in/service/UserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/UserServiceImpl.java
@@ -261,8 +261,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         return (Student) validatedUser;
     }
 
-    // TODO owner 정보 업데이트
-    // TODO 23.02.12. 박한수 개편 필요.. (사장님 관련 UPDATE는 아직 건드리지 않았음.)
+    // 기획되지 않은 기능이라 사용하지 않음.
     @Override
     @Deprecated
     public Map<String, Object> updateOwnerInformation(Owner owner) throws Exception {


### PR DESCRIPTION
## ▶ Request
### Content
#240 
### as-is
- `/lands ` , `/members` 가 soft delete 여부(불 필요)를 반환함.
- 기획에 없는 `/user/owner/me` 가 동작하고, 드러남
### to-be
- `/lands ` , `/members` 가 soft delete 여부 숨김
- 기획에 없는 `/user/owner/me` 의 동작 중지 및 숨김

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot
![image](https://github.com/BCSDLab/KOIN_API/assets/71889359/cb25bb7e-4184-45c5-b14a-151b8439c838)

![image](https://github.com/BCSDLab/KOIN_API/assets/71889359/9e9fec23-8d07-4792-88b0-7819345f2b21)



## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] `/lands ` , `/members` 가 soft delete를 반환 안하는 것을 확인
- [x] `/user/owner/me`이 성공적으로 숨겨진 것을 확인
