### PR TITLE
Task/어드민 일반 사장님 목록 반환 API

### DIFF
--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -313,6 +313,8 @@ public class AdminUserController {
     @RequestMapping(value = "/admin/users/owners", method = RequestMethod.GET)
     public @ResponseBody
     ResponseEntity<OwnersResponse> getOwners(@ModelAttribute("condition") OwnersCondition condition) {
+        condition.checkDataConstraintViolation();
+        
         return new ResponseEntity<>(adminUserService.getOwners(condition), HttpStatus.OK);
     }
 

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -26,8 +26,9 @@ import koreatech.in.dto.admin.auth.TokenRefreshRequest;
 import koreatech.in.dto.admin.auth.TokenRefreshResponse;
 import koreatech.in.dto.admin.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.admin.user.owner.response.OwnerUpdateResponse;
+import koreatech.in.dto.admin.user.owner.response.OwnersResponse;
 import koreatech.in.dto.admin.user.request.LoginRequest;
-import koreatech.in.dto.admin.user.request.NewOwnersCondition;
+import koreatech.in.dto.admin.user.request.OwnersCondition;
 import koreatech.in.dto.admin.user.response.LoginResponse;
 import koreatech.in.dto.admin.user.response.NewOwnersResponse;
 import koreatech.in.dto.admin.user.response.OwnerResponse;
@@ -285,14 +286,36 @@ public class AdminUserController {
     }
 
     @ApiOperation(value = "가입 신청한 사장님 리스트 조회 (페이지네이션)", authorizations = {@Authorization("Authorization")})
-    @RequestMapping(value = "/admin/new-owners", method = RequestMethod.GET)
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
+                    "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
+                    "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
+            @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message = "- 유효하지 않은 페이지일 때 (code: 100002)" , response = ExceptionResponse.class)
+    })
+    @RequestMapping(value = "/admin/users/new-owners", method = RequestMethod.GET)
     public @ResponseBody
-    ResponseEntity<NewOwnersResponse> getNewOwners(NewOwnersCondition condition) {
+    ResponseEntity<NewOwnersResponse> getNewOwners(OwnersCondition condition) {
         condition.checkDataConstraintViolation();
 
         NewOwnersResponse response = adminUserService.getNewOwners(condition);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @ApiOperation(value = "사장 리스트 조회 (페이지네이션)", notes = "- 어드민 권한만 허용", authorizations = {@Authorization("Authorization")})
+    @ApiResponses({
+            @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +
+                    "- 액세스 토큰이 만료되었을 때 (code: 100004) \n" +
+                    "- 액세스 토큰이 변경되었을 때 (code: 100005)", response = ExceptionResponse.class),
+            @ApiResponse(code = 403, message = "- 권한이 없을 때 (code: 100003)", response = ExceptionResponse.class),
+            @ApiResponse(code = 404, message = "- 유효하지 않은 페이지일 때 (code: 100002)" , response = ExceptionResponse.class)
+    })
+    @RequestMapping(value = "/admin/users/owners", method = RequestMethod.GET)
+    public @ResponseBody
+    ResponseEntity<OwnersResponse> getOwners(@ModelAttribute("condition") OwnersCondition condition) {
+        return new ResponseEntity<>(adminUserService.getOwners(condition), HttpStatus.OK);
+    }
+
     @ApiOperation(value = "특정 사장님 조회", notes = "- 어드민 권한만 허용", authorizations = {@Authorization(value="Authorization")})
     @ApiResponses({
         @ApiResponse(code = 401, message = "- 잘못된 접근일 때 (code: 100001) \n" +

--- a/src/main/java/koreatech/in/dto/admin/user/owner/response/OwnersResponse.java
+++ b/src/main/java/koreatech/in/dto/admin/user/owner/response/OwnersResponse.java
@@ -1,0 +1,48 @@
+package koreatech.in.dto.admin.user.owner.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@Builder
+public class OwnersResponse {
+    @ApiModelProperty(notes = "조건에 해당하는 총 사장님의 수", example = "57", required = true)
+    private Integer total_count;
+
+    @ApiModelProperty(notes = "조건에 해당하는 사장님중에 현재 페이지에서 조회된 수", example = "10", required = true)
+    private Integer current_count;
+
+    @ApiModelProperty(notes = "조건에 해당하는 사장님들을 조회할 수 있는 최대 페이지", example = "6", required = true)
+    private Integer total_page;
+
+    @ApiModelProperty(notes = "현재 페이지", example = "2", required = true)
+    private Integer current_page;
+
+    @ApiModelProperty(notes = "사장님 리스트", required = true)
+    private List<OwnersResponse.Owner> owners;
+
+    @Getter
+    @Builder
+    public static class Owner {
+        @ApiModelProperty(notes = "고유 id", required = true)
+        private Integer id;
+
+        @ApiModelProperty(notes = "이메일", required = true)
+        private String email;
+
+        @ApiModelProperty(notes = "이름")
+        private String name;
+
+        @ApiModelProperty(notes = "전화번호")
+        private String phone_number;
+
+        @ApiModelProperty(notes = "가입 신청 일자", example = "2023-01-01 12:01:02", required = true)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private Date created_at;
+    }
+}

--- a/src/main/java/koreatech/in/dto/admin/user/request/OwnersCondition.java
+++ b/src/main/java/koreatech/in/dto/admin/user/request/OwnersCondition.java
@@ -10,7 +10,7 @@ import org.apache.commons.lang.StringUtils;
 import static koreatech.in.exception.ExceptionInformation.*;
 
 @Getter @Setter
-public class NewOwnersCondition extends Criteria {
+public class OwnersCondition extends Criteria {
     @ApiParam("검색 대상 \n" +
              "- query가 null이 아닐 경우 null이면 안됨 \n" +
              "- 다음중 하나로만 요청 가능 \n" +

--- a/src/main/java/koreatech/in/mapstruct/admin/user/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/admin/user/OwnerConverter.java
@@ -7,6 +7,7 @@ import koreatech.in.domain.User.owner.OwnerShop;
 import koreatech.in.domain.User.student.Student;
 import koreatech.in.dto.admin.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.admin.user.owner.response.OwnerUpdateResponse;
+import koreatech.in.dto.admin.user.owner.response.OwnersResponse;
 import koreatech.in.dto.admin.user.response.NewOwnersResponse;
 import koreatech.in.dto.admin.user.response.OwnerResponse;
 import koreatech.in.dto.admin.user.student.request.StudentUpdateRequest;

--- a/src/main/java/koreatech/in/mapstruct/admin/user/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/admin/user/OwnerConverter.java
@@ -40,7 +40,7 @@ public interface OwnerConverter {
         @Mapping(source = "phone_number",target = "phone_number"),
         @Mapping(source = "shop_id",target = "shop_id"),
         @Mapping(source = "shop_name",target = "shop_name"),
-        @Mapping(source = "created_at",target = "created_at"),
+        @Mapping(source = "created_at",target = "created_at")
     })
     NewOwnersResponse.NewOwner toNewOwnerResponse$NewOwner(OwnerIncludingShop owner);
 
@@ -51,9 +51,29 @@ public interface OwnerConverter {
             @Mapping(source = "pageInfo.totalCount", target = "total_count"),
             @Mapping(source = "pageInfo.currentPage", target = "current_page"),
             @Mapping(source = "pageInfo.currentCount", target = "current_count"),
-            @Mapping(source = "newOwner", target = "owners")
+            @Mapping(source = "newOwners", target = "owners")
     })
-    NewOwnersResponse toNewOwnersResponse(PageInfo pageInfo, List<NewOwnersResponse.NewOwner> newOwner);
+    NewOwnersResponse toNewOwnersResponse(PageInfo pageInfo, List<NewOwnersResponse.NewOwner> newOwners);
+
+    @Mappings({
+            @Mapping(source = "id",target = "id"),
+            @Mapping(source = "email",target = "email"),
+            @Mapping(source = "name",target = "name"),
+            @Mapping(source = "phone_number",target = "phone_number"),
+            @Mapping(source = "created_at",target = "created_at")
+    })
+    OwnersResponse.Owner toOwnersResponse$Owner(Owner ownerByCondition);
+
+    List<OwnersResponse.Owner> toOwnersResponse$Owners(List<Owner> ownersByCondition);
+
+    @Mappings({
+            @Mapping(source = "pageInfo.totalPage", target = "total_page"),
+            @Mapping(source = "pageInfo.totalCount", target = "total_count"),
+            @Mapping(source = "pageInfo.currentPage", target = "current_page"),
+            @Mapping(source = "pageInfo.currentCount", target = "current_count"),
+            @Mapping(source = "owners", target = "owners")
+    })
+    OwnersResponse toOwnersResponse(PageInfo pageInfo, List<OwnersResponse.Owner> owners);
 /*
     @Named("convertAttachments")
     default List<Integer> convertAttachments(List<Integer> attachmentsId) {

--- a/src/main/java/koreatech/in/mapstruct/admin/user/OwnerConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/admin/user/OwnerConverter.java
@@ -55,14 +55,7 @@ public interface OwnerConverter {
             @Mapping(source = "newOwners", target = "owners")
     })
     NewOwnersResponse toNewOwnersResponse(PageInfo pageInfo, List<NewOwnersResponse.NewOwner> newOwners);
-
-    @Mappings({
-            @Mapping(source = "id",target = "id"),
-            @Mapping(source = "email",target = "email"),
-            @Mapping(source = "name",target = "name"),
-            @Mapping(source = "phone_number",target = "phone_number"),
-            @Mapping(source = "created_at",target = "created_at")
-    })
+    
     OwnersResponse.Owner toOwnersResponse$Owner(Owner ownerByCondition);
 
     List<OwnersResponse.Owner> toOwnersResponse$Owners(List<Owner> ownersByCondition);

--- a/src/main/java/koreatech/in/mapstruct/admin/user/UserConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/admin/user/UserConverter.java
@@ -1,7 +1,7 @@
 package koreatech.in.mapstruct.admin.user;
 
 import koreatech.in.domain.User.PageInfo;
-import koreatech.in.dto.admin.user.request.NewOwnersCondition;
+import koreatech.in.dto.admin.user.request.OwnersCondition;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
@@ -17,5 +17,5 @@ public interface UserConverter {
             @Mapping(source = "totalCount", target = "totalCount"),
             @Mapping(source = "currentCount", target = "currentCount")
     })
-    PageInfo toPageInfo(NewOwnersCondition source, Integer totalCount, Integer currentCount);
+    PageInfo toPageInfo(OwnersCondition source, Integer totalCount, Integer currentCount);
 }

--- a/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
+++ b/src/main/java/koreatech/in/repository/admin/AdminUserMapper.java
@@ -5,7 +5,7 @@ import koreatech.in.domain.User.User;
 import koreatech.in.domain.User.owner.Owner;
 import koreatech.in.domain.User.owner.OwnerIncludingShop;
 import koreatech.in.domain.User.student.Student;
-import koreatech.in.dto.admin.user.request.NewOwnersCondition;
+import koreatech.in.dto.admin.user.request.OwnersCondition;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
@@ -18,8 +18,8 @@ public interface AdminUserMapper {
     User getUndeletedUserByEmail(@Param("email") String email);
     void deleteUserLogicallyById(@Param("id") Integer id);
     void undeleteUserLogicallyById(@Param("id") Integer id);
-    Integer getTotalCountOfUnauthenticatedOwnersByCondition(@Param("condition") NewOwnersCondition condition);
-    List<OwnerIncludingShop> getUnauthenticatedOwnersByCondition(@Param("condition") NewOwnersCondition condition);
+    Integer getTotalCountOfUnauthenticatedOwnersByCondition(@Param("condition") OwnersCondition condition);
+    List<OwnerIncludingShop> getUnauthenticatedOwnersByCondition(@Param("condition") OwnersCondition condition);
     void updateOwnerAuthorById(Integer ownerId);
     Owner getFullOwnerById(@Param("id") Integer id);
     List<Integer> getShopsIdByOwnerId(Integer id);
@@ -32,4 +32,6 @@ public interface AdminUserMapper {
     void updateOwnerGrantShopByOwnerId(Integer ownerId);
     Integer getTotalCountOfStudentsByCondition(@Param("criteria") StudentCriteria criteria);
     List<Student> getStudentsByCondition(@Param("begin") Integer begin, @Param("criteria") StudentCriteria criteria);
+    Integer getTotalCountOfOwnersByCondition(@Param("condition") OwnersCondition condition);
+    List<Owner> getOwnersByCondition(@Param("condition") OwnersCondition condition);
 }

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -9,8 +9,9 @@ import koreatech.in.dto.admin.auth.TokenRefreshRequest;
 import koreatech.in.dto.admin.auth.TokenRefreshResponse;
 import koreatech.in.dto.admin.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.admin.user.owner.response.OwnerUpdateResponse;
+import koreatech.in.dto.admin.user.owner.response.OwnersResponse;
 import koreatech.in.dto.admin.user.request.LoginRequest;
-import koreatech.in.dto.admin.user.request.NewOwnersCondition;
+import koreatech.in.dto.admin.user.request.OwnersCondition;
 import koreatech.in.dto.admin.user.response.LoginResponse;
 import koreatech.in.dto.admin.user.response.NewOwnersResponse;
 import koreatech.in.dto.admin.user.student.request.StudentUpdateRequest;
@@ -50,7 +51,7 @@ public interface AdminUserService {
 
     Map<String, Object> getPermissionListForAdmin(int page, int limit) throws Exception;
 
-    NewOwnersResponse getNewOwners(NewOwnersCondition condition);
+    NewOwnersResponse getNewOwners(OwnersCondition condition);
 
     void allowOwnerPermission(Integer ownerId, Integer shopId);
 
@@ -59,4 +60,6 @@ public interface AdminUserService {
     OwnerUpdateResponse updateOwner(Integer userId, OwnerUpdateRequest request);
 
     TokenRefreshResponse refresh(TokenRefreshRequest request);
+
+    OwnersResponse getOwners(OwnersCondition criteria);
 }

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -533,6 +533,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     }
 
     @Override
+    @Transactional
     public OwnersResponse getOwners(OwnersCondition condition) {
         int totalCount = adminUserMapper.getTotalCountOfOwnersByCondition(condition);
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -47,8 +47,9 @@ import koreatech.in.dto.admin.auth.TokenRefreshRequest;
 import koreatech.in.dto.admin.auth.TokenRefreshResponse;
 import koreatech.in.dto.admin.user.owner.request.OwnerUpdateRequest;
 import koreatech.in.dto.admin.user.owner.response.OwnerUpdateResponse;
+import koreatech.in.dto.admin.user.owner.response.OwnersResponse;
 import koreatech.in.dto.admin.user.request.LoginRequest;
-import koreatech.in.dto.admin.user.request.NewOwnersCondition;
+import koreatech.in.dto.admin.user.request.OwnersCondition;
 import koreatech.in.dto.admin.user.response.LoginResponse;
 import koreatech.in.dto.admin.user.response.NewOwnersResponse;
 import koreatech.in.dto.admin.user.response.OwnerResponse;
@@ -494,7 +495,7 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Override
     @Transactional(readOnly = true)
-    public NewOwnersResponse getNewOwners(NewOwnersCondition condition) {
+    public NewOwnersResponse getNewOwners(OwnersCondition condition) {
         int totalCount = adminUserMapper.getTotalCountOfUnauthenticatedOwnersByCondition(condition);
 
         List<OwnerIncludingShop> unauthenticatedOwners = adminUserMapper.getUnauthenticatedOwnersByCondition(condition);
@@ -529,6 +530,21 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     private String getKeyForRedis(Integer id) {
         return OWNER_SHOP_REDIS_PREFIX + id;
+    }
+
+    @Override
+    public OwnersResponse getOwners(OwnersCondition condition) {
+        int totalCount = adminUserMapper.getTotalCountOfOwnersByCondition(condition);
+
+        List<Owner> ownersByCondition = adminUserMapper.getOwnersByCondition(condition);
+
+        PageInfo pageInfo = UserConverter.INSTANCE.toPageInfo(condition, totalCount, ownersByCondition.size());
+
+        List<OwnersResponse.Owner> owners = OwnerConverter.INSTANCE.toOwnersResponse$Owners(ownersByCondition);
+
+        OwnersResponse response = OwnerConverter.INSTANCE.toOwnersResponse(pageInfo, owners);
+
+        return response;
     }
 
     @Override

--- a/src/main/resources/mapper/admin/AdminUserMapper.xml
+++ b/src/main/resources/mapper/admin/AdminUserMapper.xml
@@ -217,7 +217,7 @@
     </delete>
 
     <select id="getTotalCountOfUnauthenticatedOwnersByCondition"
-            parameterType="koreatech.in.dto.admin.user.request.NewOwnersCondition" resultType="integer">
+            parameterType="koreatech.in.dto.admin.user.request.OwnersCondition" resultType="integer">
         SELECT COUNT(*)
         FROM `koin`.`users`
 
@@ -258,7 +258,7 @@
         </if>
     </select>
 
-    <select id="getUnauthenticatedOwnersByCondition" parameterType="koreatech.in.dto.admin.user.request.NewOwnersCondition" resultMap="OwnerIncludingShopResultMap">
+    <select id="getUnauthenticatedOwnersByCondition" parameterType="koreatech.in.dto.admin.user.request.OwnersCondition" resultMap="OwnerIncludingShopResultMap">
         SELECT
         `users`.`id` AS `users.id`,
         `users`.`email` AS `users.email`,
@@ -410,6 +410,75 @@
         WHERE nickname = #{nickname}
           AND id != #{userId}
             LIMIT 1;
+    </select>
+
+    <select id="getTotalCountOfOwnersByCondition"
+            parameterType="koreatech.in.dto.admin.user.request.OwnersCondition" resultType="integer">
+        SELECT COUNT(*)
+        FROM `koin`.`users`
+
+        <where>
+            <!-- 사장님만 조회 -->
+            `user_type` = 'OWNER'
+            <!-- 삭제되지 않은 회원만 조회 -->
+            AND `is_deleted` = 0
+            <if test="condition.query != null">
+                AND (
+                <if test='condition.search_type.name().equals("EMAIL")'>`email`</if>
+                <if test='condition.search_type.name().equals("NAME")'>`name`</if>
+                ) LIKE CONCAT('%', REPLACE(#{condition.query}, ' ', ''), '%')
+            </if>
+        </where>
+    </select>
+
+    <select id="getOwnersByCondition" parameterType="koreatech.in.dto.admin.user.request.OwnersCondition" resultMap="OwnerResultMap">
+        SELECT
+        `users`.`id` AS `users.id`,
+        `users`.`email` AS `users.email`,
+        `users`.`password` AS `users.password`,
+        `users`.`nickname` AS `users.nickname`,
+        `users`.`name` AS `users.name`,
+        `users`.`phone_number` AS `users.phone_number`,
+        `users`.`user_type` AS `users.user_type`,
+        `users`.`gender` AS `users.gender`,
+        `users`.`is_authed` AS `users.is_authed`,
+        `users`.`last_logged_at` AS `users.last_logged_at`,
+        `users`.`profile_image_url` AS `users.profile_image_url`,
+        `users`.`auth_token` AS `users.auth_token`,
+        `users`.`auth_expired_at` AS `users.auth_expired_at`,
+        `users`.`reset_token` AS `users.reset_token`,
+        `users`.`reset_expired_at` AS `users.reset_expired_at`,
+        `users`.`is_deleted` AS `users.is_deleted`,
+        `users`.`created_at` AS `users.created_at`,
+        `users`.`updated_at` AS `users.updated_at`,
+
+        `owners`.`company_registration_number` AS `owners.company_registration_number`,
+        `owners`.`grant_shop` AS `owners.grant_shop`,
+        `owners`.`grant_event` AS `owners.grant_event`
+
+        FROM `koin`.`users` `users`
+
+        LEFT JOIN `koin`.`owners` `owners`
+        ON `users`.`id` = `owners`.`user_id`
+
+        <where>
+            `user_type` = 'OWNER'
+            AND `is_deleted` = 0
+            <if test="condition.query != null">
+                AND (
+                <if test='condition.search_type.name().equals("EMAIL")'>`email`</if>
+                <if test='condition.search_type.name().equals("NAME")'>`name`</if>
+                ) LIKE CONCAT('%', REPLACE(#{condition.query}, ' ', ''), '%')
+            </if>
+        </where>
+
+        <if test="condition.sort != null">
+            ORDER BY
+            <if test='condition.sort.name().equals("CREATED_AT_ASC")'>`created_at` ASC</if>
+            <if test='condition.sort.name().equals("CREATED_AT_DESC")'>`created_at` DESC</if>
+        </if>
+
+        LIMIT #{condition.cursor}, #{condition.limit}
     </select>
 
     <resultMap id="UserDiscriminator" type="koreatech.in.domain.User.User">


### PR DESCRIPTION
## ▶ Request
### Content
#219 의 일반 사장님 목록
### as-is
* 어드민 페이지에서 일반 사장님 리스트를 반환하는 api가 필요
* 반환 리소스에 전화번호 포함 안됨
### to-be
* 승인 +  미승인 사장 모두 반환
* 반환 데이터에 전화번호 추가
## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지

## 📸 API Document ScreenShot
<img width="965" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/115052407/e0c472b5-6ca6-48e2-b143-895c436b311e">
<img width="953" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/115052407/bc0449c5-c1bb-40c8-82fe-5448c8d81f64">



## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x]  로컬환경에서 페이지네이션 동작 확인(query, sort, page, limit)
- [x]  로컬환경에서 db에 테스트용 데이터 추가 후 api 정상 동작 확인

