### PR TITLE
Fix: 사업자등록번호 유니크 검증

### DIFF
--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -113,8 +113,9 @@ public class OwnerController {
     @ApiResponses({
             @ApiResponse(
                     code = 409,
-                    message = "- 인증이 되지 않은 이메일일 경우 (code: 101012) \n\n"
-                            + "- 이미 누군가 사용중인 이메일일 경우 (code: 101013)",
+                    message = "- 인증이 되지 않은 이메일일 경우 (code: 101012)"
+                            + "\n\n- 이미 누군가 사용중인 이메일일 경우 (code: 101013)"
+                            + "\n\n- 이미 누군가 사용중인 사업자등록번호일 경우 (code: 101021)",
                     response = ExceptionResponse.class),
             @ApiResponse(
                     code = 410,

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -16,9 +16,9 @@ public interface OwnerMapper {
 
     void insertOwner(Owner owner);
 
-    void safeDeleteOwner(Owner owner);
+//    void safeDeleteOwner(Owner owner);
 
-    void deleteOwner(Integer id);
+//    void deleteOwner(Integer id);
 
     OwnerAttachment getOwnerAttachmentById(Long id);
 
@@ -30,4 +30,6 @@ public interface OwnerMapper {
     void insertOwnerAttachment(OwnerAttachment attachment);
 
     void deleteOwnerAttachmentsLogically(OwnerAttachments ownerAttachments);
+
+    boolean isCompanyRegistrationNumberExist(String companyRegistrationNumber);
 }

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -113,4 +113,12 @@
         SET is_deleted = TRUE
         WHERE id = #{id}
     </update>
+
+
+    <select id="isCompanyRegistrationNumberExist" resultType="boolean">
+        SELECT IF (count(*) != 0, 1, 0)
+        FROM koin.owners
+        WHERE company_registration_number = #{companyRegistrationNumber}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## ▶ Request
### Content
<!-- 이슈 번호가 있으면 적어주세요. e.g. #13 -->
### as-is
- 회원가입 시 사업자등록번호에 대한 검증이 존재하지 않고, `todo`로 남아있었음.
### to-be
- owner.service에서 register가 일어날 경우 사업자등록번호에 대한 검증을 추가함

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot
![image](https://github.com/BCSDLab/KOIN_API/assets/71889359/bee60296-8ff0-42f7-b227-221650591bee)


## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] 사업자등록번호가 검증됨을 확인
- [x] 컨트롤러 변경 확인


## Remark

### 유니크 검증을 위해 어떤 쿼리를 날릴지 ?
`getOwnerByEmailOrRegisrationNumber `처럼 사업자번호 검증과 이메일 검증까지 한꺼번에 하여 성능을 높일 수도 있었으나, 이미 존재하고 있는 이메일 검증 메서드의 의미가 퇴색될 것 같고, 추후 사업자번호나 이메일에 대한 각각의 검증만이 필요할 수 있을 것 같아 별도 쿼리를 추가함(`isCompanyRegistrationNumberExist`)
### 검증 위치와 방식은 어떻게 할지?
DTO에 `ConstraintValidator` 를 활용하여 유니크 검증을 하는 사례도 있었는데, Controller에서 처리하기에 적합한 검증은 아니라고 생각하여 Service에서 메서드로 처리하도록 함.

**계층별 검증 역할 (생각)**
- Controller: 입력값이 제한사항을 지켰는지 검증
- Service: 값이 비지니스로직에 적합한지 검증

## Review Point
- `ConstraintValidator`를 활용하지 않은 것에 대한 의견
- 사용한 쿼리에 대한 의견
- 추가적으로 사업자등록번호 검증이 필요한 다른 API들이 있는지에 대한 의견 
등
