### PR TITLE
Task: 비밀번호 변경을 위한 인증 번호 입력 기능

### DIFF
--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -66,7 +66,7 @@ public class OwnerController {
     @RequestMapping(value = "/owners/password/reset/send", method = RequestMethod.POST)
     @ParamValid
     public @ResponseBody
-    ResponseEntity<VerifyCodeResponse> verifyCodeToChangePassword(@RequestBody @Valid VerifyCodeRequest request,
+    ResponseEntity<EmptyResponse> verifyCodeToChangePassword(@RequestBody @Valid VerifyCodeRequest request,
                                                   BindingResult bindingResult) {
         try {
             request = StringXssChecker.xssCheck(request, request.getClass().newInstance());

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -48,6 +48,39 @@ public class OwnerController {
     @ApiResponses({
             @ApiResponse(
                     code = 409,
+                    message = "- 이미 인증이 완료된 이메일일 경우 (code: 101011) \n\n",
+                    response = ExceptionResponse.class),
+            @ApiResponse(
+                    code = 410,
+                    message = "- 저장기간(`2시간`)이 만료된 이메일일 경우 (code: 101010) \n\n"
+                            + "- 코드 인증 기한(`5분`)이 경과된 경우 (code: 121001) \n\n",
+                    response = ExceptionResponse.class),
+            @ApiResponse(
+                    code = 422,
+                    message = "- 요청 데이터 제약조건이 지켜지지 않았을 때 (error code: 100000)"
+                            + "- 인증 코드가 일치하지 않을 경우 (code: 121002) \n\n",
+                    response = RequestDataInvalidResponse.class)
+    })
+    @ApiOperation(value = "비밀번호 변경 인증번호 입력")
+    @AuthExcept
+    @RequestMapping(value = "/owners/password/reset/send", method = RequestMethod.POST)
+    @ParamValid
+    public @ResponseBody
+    ResponseEntity<VerifyCodeResponse> verifyCodeToChangePassword(@RequestBody @Valid VerifyCodeRequest request,
+                                                  BindingResult bindingResult) {
+        try {
+            request = StringXssChecker.xssCheck(request, request.getClass().newInstance());
+        } catch (Exception exception) {
+            throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
+        }
+
+        ownerService.certificateToChangePassword(request);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @ApiResponses({
+            @ApiResponse(
+                    code = 409,
                     message = "- 이미 인증이 완료된 이메일일 경우 (code: 101011) \n\n"
                             + "- 이미 누군가 사용중인 이메일일 경우 (code: 101013)",
                     response = ExceptionResponse.class),

--- a/src/main/java/koreatech/in/domain/Redis.java
+++ b/src/main/java/koreatech/in/domain/Redis.java
@@ -1,0 +1,16 @@
+package koreatech.in.domain;
+
+public enum Redis {
+    ownerAuthPrefix("owner@"),
+    ownerChangePasswordAuthPrefix("owner_password_change@");
+
+    private final String prefixOfKey;
+
+    Redis(String prefixOfKey) {
+        this.prefixOfKey = prefixOfKey;
+    }
+
+    public String getKey(String suffix) {
+        return prefixOfKey+suffix;
+    }
+}

--- a/src/main/java/koreatech/in/domain/RedisOwnerKeyPrefix.java
+++ b/src/main/java/koreatech/in/domain/RedisOwnerKeyPrefix.java
@@ -1,12 +1,12 @@
 package koreatech.in.domain;
 
-public enum Redis {
+public enum RedisOwnerKeyPrefix {
     ownerAuthPrefix("owner@"),
     ownerChangePasswordAuthPrefix("owner_password_change@");
 
     private final String prefixOfKey;
 
-    Redis(String prefixOfKey) {
+    RedisOwnerKeyPrefix(String prefixOfKey) {
         this.prefixOfKey = prefixOfKey;
     }
 

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -26,7 +26,7 @@ public enum ExceptionInformation {
     IMPOSSIBLE_UNDELETE_USER_BECAUSE_SAME_EMAIL_EXIST("탈퇴하지 않은 회원 중 같은 이메일을 가진 회원이 있어, 탈퇴를 해제할 수 없습니다.", 101007, HttpStatus.CONFLICT),
     EMAIL_ADDRESS_INVALID("유효하지 않는 이메일 주소입니다.", 101008, HttpStatus.UNPROCESSABLE_ENTITY),
     EMAIL_DOMAIN_INVALID("유효하지 않는 이메일 도메인입니다.", 101009, HttpStatus.UNPROCESSABLE_ENTITY),
-    EMAIL_ADDRESS_SAVE_EXPIRED("저장기간이 만료된 이메일 주소입니다. 다시 회원가입을 시도해주세요.", 101010, HttpStatus.GONE),
+    EMAIL_ADDRESS_SAVE_EXPIRED("저장기간이 만료된 이메일 주소입니다. 다시 시도해주세요.", 101010, HttpStatus.GONE),
     CERTIFICATION_CODE_ALREADY_COMPLETED("해당 이메일은 이미 인증 완료되었습니다.", 101011, HttpStatus.CONFLICT),
     CERTIFICATION_CODE_NOT_COMPLETED("해당 이메일은 인증되지 않았습니다.", 101012, HttpStatus.CONFLICT),
     EMAIL_DUPLICATED("이미 존재하는 이메일 주소입니다. 다른 이메일 주소를 사용해주세요.", 101013, HttpStatus.CONFLICT),

--- a/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
@@ -18,7 +18,7 @@ public class RedisOwnerMapper {
     @Autowired
     private StringRedisUtilObj stringRedisUtilObj;
 
-    public void changeRedis(OwnerInCertification ownerInCertification, String email, RedisOwnerKeyPrefix redisOwnerKeyPrefix) {
+    public void changeAuthStatus(OwnerInCertification ownerInCertification, String email, RedisOwnerKeyPrefix redisOwnerKeyPrefix) {
         String key = redisOwnerKeyPrefix.getKey(email);
         OwnerInVerification ownerInRedis = getOwnerInRedis(key);
 

--- a/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
@@ -1,0 +1,60 @@
+package koreatech.in.repository;
+
+import koreatech.in.domain.Redis;
+import koreatech.in.domain.User.owner.OwnerInCertification;
+import koreatech.in.domain.User.owner.OwnerInVerification;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
+import koreatech.in.util.StringRedisUtilObj;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class RedisOwnerMapper {
+
+    @Autowired
+    private StringRedisUtilObj stringRedisUtilObj;
+
+    public void changeRedis(OwnerInCertification ownerInCertification, String email, Redis redis) {
+        String key = redis.getKey(email);
+        OwnerInVerification ownerInRedis = getOwnerInRedis(key);
+
+        ownerInRedis.validateFor(ownerInCertification);
+        ownerInRedis.setIs_authed(true);
+
+        putRedisFor(key, ownerInRedis);
+    }
+
+    private OwnerInVerification getOwnerInRedis(String key) {
+        Object json;
+        try {
+            json = stringRedisUtilObj.getDataAsString(key, OwnerInVerification.class);
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+
+        OwnerInVerification ownerInRedis = (OwnerInVerification) json;
+        validateRedis(ownerInRedis);
+
+        return ownerInRedis;
+    }
+
+    private static void validateRedis(OwnerInVerification ownerInRedis) {
+        if (ownerInRedis == null) {
+            throw new BaseException(ExceptionInformation.EMAIL_ADDRESS_SAVE_EXPIRED);
+        }
+        ownerInRedis.validateFields();
+    }
+
+    private void putRedisFor(String ownerKey, OwnerInVerification ownerInVerification) {
+        try {
+            stringRedisUtilObj.setDataAsString(ownerKey,
+                    ownerInVerification, 2L, TimeUnit.HOURS);
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
@@ -28,7 +28,7 @@ public class RedisOwnerMapper {
         putRedisFor(key, ownerInRedis);
     }
 
-    private OwnerInVerification getOwnerInRedis(String key) {
+    public OwnerInVerification getOwnerInRedis(String key) {
         Object json;
         try {
             json = stringRedisUtilObj.getDataAsString(key, OwnerInVerification.class);
@@ -49,7 +49,7 @@ public class RedisOwnerMapper {
         ownerInRedis.validateFields();
     }
 
-    private void putRedisFor(String ownerKey, OwnerInVerification ownerInVerification) {
+    public void putRedisFor(String ownerKey, OwnerInVerification ownerInVerification) {
         try {
             stringRedisUtilObj.setDataAsString(ownerKey,
                     ownerInVerification, 2L, TimeUnit.HOURS);

--- a/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
@@ -1,6 +1,6 @@
 package koreatech.in.repository;
 
-import koreatech.in.domain.Redis;
+import koreatech.in.domain.RedisOwnerKeyPrefix;
 import koreatech.in.domain.User.owner.OwnerInCertification;
 import koreatech.in.domain.User.owner.OwnerInVerification;
 import koreatech.in.exception.BaseException;
@@ -18,8 +18,8 @@ public class RedisOwnerMapper {
     @Autowired
     private StringRedisUtilObj stringRedisUtilObj;
 
-    public void changeRedis(OwnerInCertification ownerInCertification, String email, Redis redis) {
-        String key = redis.getKey(email);
+    public void changeRedis(OwnerInCertification ownerInCertification, String email, RedisOwnerKeyPrefix redisOwnerKeyPrefix) {
+        String key = redisOwnerKeyPrefix.getKey(email);
         OwnerInVerification ownerInRedis = getOwnerInRedis(key);
 
         ownerInRedis.validateFor(ownerInCertification);

--- a/src/main/java/koreatech/in/service/OwnerService.java
+++ b/src/main/java/koreatech/in/service/OwnerService.java
@@ -20,4 +20,6 @@ public interface OwnerService {
     void deleteAttachment(Integer attachmentId);
 
     OwnerResponse update(OwnerUpdateRequest ownerUpdateRequest);
+
+    void certificateToChangePassword(VerifyCodeRequest request);
 }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -1,13 +1,10 @@
 package koreatech.in.service;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import koreatech.in.domain.Redis;
 import koreatech.in.domain.User.EmailAddress;
 import koreatech.in.domain.User.owner.CertificationCode;
 import koreatech.in.domain.User.owner.Owner;
@@ -15,7 +12,6 @@ import koreatech.in.domain.User.owner.OwnerAttachment;
 import koreatech.in.domain.User.owner.OwnerAttachments;
 import koreatech.in.domain.User.owner.OwnerInCertification;
 import koreatech.in.domain.User.owner.OwnerInVerification;
-import koreatech.in.domain.User.owner.OwnerPartition;
 import koreatech.in.domain.User.owner.OwnerShop;
 import koreatech.in.dto.normal.user.owner.request.OwnerRegisterRequest;
 import koreatech.in.dto.normal.user.owner.request.OwnerUpdateRequest;
@@ -32,7 +28,6 @@ import koreatech.in.repository.user.UserMapper;
 import koreatech.in.util.RandomGenerator;
 import koreatech.in.util.SesMailSender;
 import koreatech.in.util.SlackNotiSender;
-import koreatech.in.util.StringRedisUtilStr;
 import koreatech.in.util.StringRedisUtilObj;
 import koreatech.in.util.jwt.TemporaryAccessJwtGenerator;
 import org.apache.velocity.app.VelocityEngine;
@@ -42,7 +37,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.velocity.VelocityEngineUtils;
 
-import static koreatech.in.domain.Redis.*;
+import static koreatech.in.domain.RedisOwnerKeyPrefix.*;
 
 @Service
 public class OwnerServiceImpl implements OwnerService {

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -78,7 +78,7 @@ public class OwnerServiceImpl implements OwnerService {
     @Override
     public void certificateToChangePassword(VerifyCodeRequest verifyCodeRequest) {
         OwnerInCertification ownerInCertification = OwnerConverter.INSTANCE.toOwnerInCertification(verifyCodeRequest);
-        redisOwnerMapper.changeRedis(ownerInCertification, ownerInCertification.getEmail(), ownerChangePasswordAuthPrefix);
+        redisOwnerMapper.changeAuthStatus(ownerInCertification, ownerInCertification.getEmail(), ownerChangePasswordAuthPrefix);
     }
 
     @Override
@@ -101,7 +101,7 @@ public class OwnerServiceImpl implements OwnerService {
     @Override
     public VerifyCodeResponse certificate(VerifyCodeRequest verifyCodeRequest) {
         OwnerInCertification ownerInCertification = OwnerConverter.INSTANCE.toOwnerInCertification(verifyCodeRequest);
-        redisOwnerMapper.changeRedis(ownerInCertification, ownerInCertification.getEmail(), ownerAuthPrefix);
+        redisOwnerMapper.changeAuthStatus(ownerInCertification, ownerInCertification.getEmail(), ownerAuthPrefix);
         String temporaryAccessToken = temporaryAccessJwtGenerator.generateToken(null);
         return OwnerConverter.INSTANCE.toVerifyCodeResponse(temporaryAccessToken);
     }

--- a/src/main/java/koreatech/in/util/StringRedisUtilObj.java
+++ b/src/main/java/koreatech/in/util/StringRedisUtilObj.java
@@ -19,6 +19,7 @@ public class StringRedisUtilObj extends StringRedisUtil<Object> {
 
     private static final String redisOwnerAuthPrefix = "owner@";
     private static final String redisOwnerShopPrefix = "owner_shop@";
+    private static final String redisOwnerChangePasswordAuthPrefix = "owner_password_change@";
 
     @Resource(name = "redisTemplate")
     private RedisTemplate<String, Object> redisTemplate;
@@ -121,5 +122,9 @@ public class StringRedisUtilObj extends StringRedisUtil<Object> {
 
     public static String makeOwnerShopKeyFor(Integer ownerId) {
         return redisOwnerShopPrefix + ownerId;
+    }
+
+    public static String makeOwnerKeyToChangePassword(String emailAddress) {
+        return redisOwnerChangePasswordAuthPrefix + emailAddress;
     }
 }

--- a/src/main/java/koreatech/in/util/StringRedisUtilObj.java
+++ b/src/main/java/koreatech/in/util/StringRedisUtilObj.java
@@ -19,7 +19,6 @@ public class StringRedisUtilObj extends StringRedisUtil<Object> {
 
     private static final String redisOwnerAuthPrefix = "owner@";
     private static final String redisOwnerShopPrefix = "owner_shop@";
-    private static final String redisOwnerChangePasswordAuthPrefix = "owner_password_change@";
 
     @Resource(name = "redisTemplate")
     private RedisTemplate<String, Object> redisTemplate;
@@ -122,9 +121,5 @@ public class StringRedisUtilObj extends StringRedisUtil<Object> {
 
     public static String makeOwnerShopKeyFor(Integer ownerId) {
         return redisOwnerShopPrefix + ownerId;
-    }
-
-    public static String makeOwnerKeyToChangePassword(String emailAddress) {
-        return redisOwnerChangePasswordAuthPrefix + emailAddress;
     }
 }

--- a/src/main/java/koreatech/in/util/StringRedisUtilObj.java
+++ b/src/main/java/koreatech/in/util/StringRedisUtilObj.java
@@ -17,8 +17,6 @@ import java.util.Set;
 @Component
 public class StringRedisUtilObj extends StringRedisUtil<Object> {
 
-    private static final String redisOwnerAuthPrefix = "owner@";
-    private static final String redisOwnerChangePasswordAuthPrefix = "owner_password_change@";
     private static final String redisOwnerShopPrefix = "owner_shop@";
 
     @Resource(name = "redisTemplate")
@@ -114,14 +112,6 @@ public class StringRedisUtilObj extends StringRedisUtil<Object> {
 
     public void deleteData(String key) {
         redisTemplate.delete(key);
-    }
-
-    public static String makeOwnerKeyFor(String emailAddress) {
-        return redisOwnerAuthPrefix + emailAddress;
-    }
-
-    public static String makeOwnerPasswordChangeKeyFor(String emailAddress) {
-        return redisOwnerChangePasswordAuthPrefix + emailAddress;
     }
 
     public static String makeOwnerShopKeyFor(Integer ownerId) {

--- a/src/main/java/koreatech/in/util/StringRedisUtilStr.java
+++ b/src/main/java/koreatech/in/util/StringRedisUtilStr.java
@@ -15,6 +15,7 @@ import java.util.Set;
 public class StringRedisUtilStr extends StringRedisUtil<String> {
 
     private static final String redisOwnerAuthPrefix = "owner@";
+    private static final String redisOwnerChangePasswordAuthPrefix = "owner_password_change@";
 
     @Resource(name = "stringRedisTemplate")
     private StringRedisTemplate redisTemplate;
@@ -66,5 +67,9 @@ public class StringRedisUtilStr extends StringRedisUtil<String> {
 
     public  static String makeOwnerKeyFor(String emailAddress) {
         return redisOwnerAuthPrefix + emailAddress;
+    }
+
+    public static String makeOwnerKeyToChangePassword(String emailAddress) {
+        return redisOwnerChangePasswordAuthPrefix + emailAddress;
     }
 }

--- a/src/main/java/koreatech/in/util/StringRedisUtilStr.java
+++ b/src/main/java/koreatech/in/util/StringRedisUtilStr.java
@@ -14,9 +14,6 @@ import java.util.Set;
 @Component
 public class StringRedisUtilStr extends StringRedisUtil<String> {
 
-    private static final String redisOwnerAuthPrefix = "owner@";
-    private static final String redisOwnerChangePasswordAuthPrefix = "owner_password_change@";
-
     @Resource(name = "stringRedisTemplate")
     private StringRedisTemplate redisTemplate;
 
@@ -65,11 +62,4 @@ public class StringRedisUtilStr extends StringRedisUtil<String> {
         redisTemplate.delete(key);
     }
 
-    public  static String makeOwnerKeyFor(String emailAddress) {
-        return redisOwnerAuthPrefix + emailAddress;
-    }
-
-    public static String makeOwnerKeyToChangePassword(String emailAddress) {
-        return redisOwnerChangePasswordAuthPrefix + emailAddress;
-    }
 }


### PR DESCRIPTION
## ▶ Request
### Content
#264 
### as-is

### to-be
**비밀번호 변경을 위해 이메일로 받은 인증 번호를 입력하는 API**
- 기존의 `getOwnerInRedis()`와 `putRedisFor()` 메서드에서 변경한 점
  - 메서드를 호출하기 전에 redis key를 만들어서 메서드로 전달하도록 변경

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot
<img width="550" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/106418303/f5aaea3b-25c9-428b-883c-bf14a30b2dbd">

## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] 이메일, 인증코드 입력 시 is_ahthed = true 로 바뀌는 걸 확인
- [x] 이미 인증 완료한 경우 예외가 발생하는지 확인
- [x] 코드 인증 기한이 경과된 경우 예외가 발생하는지 확인
- [x] 회원가입 api도 잘 동작하는지 확인
