### PR TITLE
Refactor: 파일 업로드 컨트롤러에 컨버터 도입

### DIFF
--- a/src/main/java/koreatech/in/config/WebConfig.java
+++ b/src/main/java/koreatech/in/config/WebConfig.java
@@ -1,4 +1,4 @@
-package koreatech.in.converter;
+package koreatech.in.config;
 
 import java.util.Collections;
 
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ConversionServiceFactoryBean;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import koreatech.in.converter.DomainEnumConvertor;
 
 @Configuration
 @EnableWebMvc

--- a/src/main/java/koreatech/in/controller/UploadController.java
+++ b/src/main/java/koreatech/in/controller/UploadController.java
@@ -50,9 +50,6 @@ import koreatech.in.util.UploadFileUtils;
 @Auth(role = Auth.Role.USER)
 @Controller
 public class UploadController {
-    private final static String UPLOAD_DIRECTORY_NAME = "upload";
-    private final static String SLASH = "/";
-    private final static String ADMIN_PATH = "/admin";
 
     @Autowired
     private UploadFileUtils uploadFileUtils;
@@ -180,10 +177,6 @@ public class UploadController {
         return new ResponseEntity<>(uploadFilesResponse, HttpStatus.CREATED);
     }
 
-    public static String enrichDomainPath(String domain) {
-        return UPLOAD_DIRECTORY_NAME + SLASH + domain.toLowerCase();
-    }
-
     // 업로드 전용 단일 파일 업로드
     // 어드민 전용 설정을 원한다면, Auth를 메서드별로 설정 & 인터셉터에서 인식 가능케 코드 변경 & Upload에 대한 Authority DB, enum, 인터셉터에 추가 해야 함.
     @Deprecated
@@ -296,7 +289,7 @@ public class UploadController {
                     + "  - ContentType: `image/*`\n"
                     + "  - MaxSize: `10mb`\n"
                     , required = true)
-            @PathVariable String domain, @ApiParam(required = true) @RequestBody @Valid
+            @PathVariable DomainEnum domain, @ApiParam(required = true) @RequestBody @Valid
             PreSignedUrlRequest request, BindingResult bindingResult) {
 
         try {

--- a/src/main/java/koreatech/in/controller/UploadController.java
+++ b/src/main/java/koreatech/in/controller/UploadController.java
@@ -177,15 +177,8 @@ public class UploadController {
                     + "- `owners`\n"
                     + "  - ContentType: `image/*`\n"
                     + "  - MaxSize: `10mb`\n"
-                    , required = true) @PathVariable String domain) {
-
-        DomainEnum domainEnum = DomainEnum.mappingFor(domain);
-        files.forEach(domainEnum::validateFor);
-
-        UploadFilesRequest uploadFilesRequest = UploadFilesRequest.of(files, enrichDomainPath(domain));
-
-        UploadFilesResponse uploadFilesResponse = s3uploadService.uploadAndGetUrls(uploadFilesRequest);
-
+                    , required = true) @PathVariable DomainEnum domain) {
+        UploadFilesResponse uploadFilesResponse = s3uploadService.uploadAndGetUrls(files, domain);
         return new ResponseEntity<>(uploadFilesResponse, HttpStatus.CREATED);
     }
 

--- a/src/main/java/koreatech/in/controller/UploadController.java
+++ b/src/main/java/koreatech/in/controller/UploadController.java
@@ -1,5 +1,6 @@
 package koreatech.in.controller;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -129,16 +130,13 @@ public class UploadController {
                     + "- `owners`\n"
                     + "  - ContentType: `image/*`\n"
                     + "  - MaxSize: `10mb`\n"
-                    , example = "items", required = true) @PathVariable String domain) {
-
-        DomainEnum domainEnum = DomainEnum.mappingFor(domain);
-        domainEnum.validateFor(multipartFile);
-
-        UploadFileRequest uploadFileRequest = UploadFileRequest.of(enrichDomainPath(domain), multipartFile);
-
-        UploadFileResponse uploadFileResponse = s3uploadService.uploadAndGetUrl(uploadFileRequest);
-
-        return new ResponseEntity<>(uploadFileResponse, HttpStatus.CREATED);
+                , example = "items", required = true) @PathVariable DomainEnum domain) {
+        try {
+            UploadFileResponse uploadFileResponse = s3uploadService.uploadAndGetUrl(multipartFile, domain);
+            return new ResponseEntity<>(uploadFileResponse, HttpStatus.CREATED);
+        } catch (IOException e) {
+            throw new BaseException(ExceptionInformation.FILE_INVALID);
+        }
     }
 
     // 다중 파일 업로드

--- a/src/main/java/koreatech/in/converter/DomainEnumConvertor.java
+++ b/src/main/java/koreatech/in/converter/DomainEnumConvertor.java
@@ -1,11 +1,9 @@
 package koreatech.in.converter;
 
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.stereotype.Component;
 
 import koreatech.in.domain.Upload.DomainEnum;
 
-@Component
 public class DomainEnumConvertor implements Converter<String, DomainEnum> {
     @Override
     public DomainEnum convert(String domainPathVariable) {

--- a/src/main/java/koreatech/in/domain/Upload/DomainEnum.java
+++ b/src/main/java/koreatech/in/domain/Upload/DomainEnum.java
@@ -17,6 +17,9 @@ public enum DomainEnum {
     private final ContentTypes expectContentTypes;
     private final ByteSize limitedSize;
 
+    private final static String UPLOAD_DIRECTORY_NAME = "upload";
+    private final static String SLASH = "/";
+    private final static String ADMIN_PATH = "/admin";
 
     DomainEnum() {
         expectContentTypes = ContentTypes.DEFAULT ;
@@ -41,9 +44,17 @@ public enum DomainEnum {
         limitedSize.validateAcceptable(ByteSize.from(uploadFileMetaData.getContentLength()));
     }
 
-    private static void validates(MultipartFile multipartFile) {
+    private void validates(MultipartFile multipartFile) {
         if(multipartFile == null  || multipartFile.isEmpty()) {
             throw new BaseException(ExceptionInformation.FILE_INVALID);
         }
+    }
+
+    public String enrichDomainPath() {
+        return UPLOAD_DIRECTORY_NAME + SLASH + this.name().toLowerCase();
+    }
+
+    public String enrichDomainPathForAdmin() {
+        return UPLOAD_DIRECTORY_NAME + SLASH + this.name().toLowerCase() + ADMIN_PATH;
     }
 }

--- a/src/main/java/koreatech/in/domain/Upload/UploadFile.java
+++ b/src/main/java/koreatech/in/domain/Upload/UploadFile.java
@@ -25,8 +25,8 @@ public class UploadFile {
         return fullPath.getFileFullName();
     }
 
-    public static UploadFile of(MultipartFile multipartFile, DomainEnum domain) throws IOException {
-        UploadFileFullPath uploadFileFullPath = UploadFileFullPath.of(domain.enrichDomainPath(), multipartFile.getOriginalFilename());
+    public static UploadFile of(MultipartFile multipartFile, String domainPath) throws IOException {
+        UploadFileFullPath uploadFileFullPath = UploadFileFullPath.of(domainPath, multipartFile.getOriginalFilename());
 
         return new UploadFile(uploadFileFullPath, multipartFile.getBytes());
     }

--- a/src/main/java/koreatech/in/domain/Upload/UploadFile.java
+++ b/src/main/java/koreatech/in/domain/Upload/UploadFile.java
@@ -1,5 +1,9 @@
 package koreatech.in.domain.Upload;
 
+import java.io.IOException;
+
+import org.springframework.web.multipart.MultipartFile;
+
 import lombok.AllArgsConstructor;
 
 
@@ -19,5 +23,11 @@ public class UploadFile {
 
     public String getFileName() {
         return fullPath.getFileFullName();
+    }
+
+    public static UploadFile of(MultipartFile multipartFile, DomainEnum domain) throws IOException {
+        UploadFileFullPath uploadFileFullPath = UploadFileFullPath.of(domain.enrichDomainPath(), multipartFile.getOriginalFilename());
+
+        return new UploadFile(uploadFileFullPath, multipartFile.getBytes());
     }
 }

--- a/src/main/java/koreatech/in/domain/Upload/UploadFiles.java
+++ b/src/main/java/koreatech/in/domain/Upload/UploadFiles.java
@@ -1,13 +1,40 @@
 package koreatech.in.domain.Upload;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
 import lombok.AllArgsConstructor;
 
 
 @AllArgsConstructor
 public class UploadFiles {
     private final List<UploadFile> uploadFiles;
+
+    public static UploadFiles of(List<MultipartFile> multipartFiles, DomainEnum domain) {
+        List<UploadFile> files = multipartFiles
+            .stream()
+            .map(makeFile(domain))
+            .collect(Collectors.toList());
+
+        return new UploadFiles(files);
+    }
+
+    private static Function<MultipartFile, UploadFile> makeFile(DomainEnum domain) {
+        return multipartFile -> {
+            try {
+                return UploadFile.of(multipartFile, domain);
+            } catch (IOException e) {
+                throw new BaseException(ExceptionInformation.FILE_INVALID);
+            }
+        };
+    }
 
     public List<UploadFile> getUploadFiles() {
         return Collections.unmodifiableList(uploadFiles);

--- a/src/main/java/koreatech/in/domain/Upload/UploadFiles.java
+++ b/src/main/java/koreatech/in/domain/Upload/UploadFiles.java
@@ -3,7 +3,6 @@ package koreatech.in.domain.Upload;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -12,28 +11,24 @@ import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ExceptionInformation;
 import lombok.AllArgsConstructor;
 
-
 @AllArgsConstructor
 public class UploadFiles {
     private final List<UploadFile> uploadFiles;
 
     public static UploadFiles of(List<MultipartFile> multipartFiles, String domainPath) {
-        List<UploadFile> files = multipartFiles
-            .stream()
-            .map(makeFile(domainPath))
+        List<UploadFile> files = multipartFiles.stream()
+            .map(multipartFile ->  makeFile(multipartFile, domainPath))
             .collect(Collectors.toList());
 
         return new UploadFiles(files);
     }
 
-    private static Function<MultipartFile, UploadFile> makeFile(String domainPath) {
-        return multipartFile -> {
-            try {
-                return UploadFile.of(multipartFile, domainPath);
-            } catch (IOException e) {
-                throw new BaseException(ExceptionInformation.FILE_INVALID);
-            }
-        };
+    private static UploadFile makeFile(MultipartFile multipartFile, String domainPath) {
+        try {
+            return UploadFile.of(multipartFile, domainPath);
+        } catch (IOException e) {
+            throw new BaseException(ExceptionInformation.FILE_INVALID);
+        }
     }
 
     public List<UploadFile> getUploadFiles() {

--- a/src/main/java/koreatech/in/domain/Upload/UploadFiles.java
+++ b/src/main/java/koreatech/in/domain/Upload/UploadFiles.java
@@ -17,19 +17,19 @@ import lombok.AllArgsConstructor;
 public class UploadFiles {
     private final List<UploadFile> uploadFiles;
 
-    public static UploadFiles of(List<MultipartFile> multipartFiles, DomainEnum domain) {
+    public static UploadFiles of(List<MultipartFile> multipartFiles, String domainPath) {
         List<UploadFile> files = multipartFiles
             .stream()
-            .map(makeFile(domain))
+            .map(makeFile(domainPath))
             .collect(Collectors.toList());
 
         return new UploadFiles(files);
     }
 
-    private static Function<MultipartFile, UploadFile> makeFile(DomainEnum domain) {
+    private static Function<MultipartFile, UploadFile> makeFile(String domainPath) {
         return multipartFile -> {
             try {
-                return UploadFile.of(multipartFile, domain);
+                return UploadFile.of(multipartFile, domainPath);
             } catch (IOException e) {
                 throw new BaseException(ExceptionInformation.FILE_INVALID);
             }

--- a/src/main/java/koreatech/in/mapstruct/normal/upload/UploadFileConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/normal/upload/UploadFileConverter.java
@@ -1,6 +1,5 @@
 package koreatech.in.mapstruct.normal.upload;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -9,9 +8,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
-import org.springframework.web.multipart.MultipartFile;
 
-import koreatech.in.domain.Upload.DomainEnum;
 import koreatech.in.domain.Upload.PreSignedUrlResult;
 import koreatech.in.domain.Upload.UploadFile;
 import koreatech.in.domain.Upload.UploadFileFullPath;
@@ -45,16 +42,6 @@ public interface UploadFileConverter {
         @Mapping(source = "data", target = "data")
     })
     UploadFile toUploadFile(UploadFileRequest uploadFileRequest);
-
-    @Mappings({
-        @Mapping(source = ".", target = "fullPath", qualifiedByName = "convertFullPath"),
-        @Mapping(source = "data", target = "data")
-    })
-    default UploadFile toUploadFile(MultipartFile multipartFile, DomainEnum domain) throws IOException {
-        UploadFileFullPath uploadFileFullPath = UploadFileFullPath.of(domain.enrichDomainPath(), multipartFile.getOriginalFilename());
-
-        return new UploadFile(uploadFileFullPath, multipartFile.getBytes());
-    }
 
     @Named("convertFullPath")
     default UploadFileFullPath convertFullPath(UploadFileRequest uploadFileRequest) {

--- a/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
+++ b/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
@@ -2,12 +2,14 @@ package koreatech.in.service;
 
 import static koreatech.in.controller.UploadController.enrichDomainPath;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import koreatech.in.domain.Upload.DomainEnum;
 import koreatech.in.domain.Upload.PreSignedUrlResult;
@@ -49,6 +51,17 @@ public class S3UploadServiceImpl implements UploadService {
         uploadFor(file);
         UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainName, file);
 
+        return UploadFileConverter.INSTANCE.toUploadFileResponse(uploadFileLocation);
+    }
+
+    @Override
+    public UploadFileResponse uploadAndGetUrl(MultipartFile multipartFile, DomainEnum domain) throws IOException {
+        domain.validateFor(multipartFile);
+
+        UploadFile file = UploadFile.of(multipartFile, domain);
+        uploadFor(file);
+
+        UploadFileLocation uploadFileLocation = UploadFileLocation.of(domain.enrichDomainPath(), file);
         return UploadFileConverter.INSTANCE.toUploadFileResponse(uploadFileLocation);
     }
 

--- a/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
+++ b/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
@@ -5,6 +5,7 @@ import static koreatech.in.controller.UploadController.enrichDomainPath;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -71,6 +72,16 @@ public class S3UploadServiceImpl implements UploadService {
 
         UploadFilesLocation uploadFilesLocation = uploadAndGetUrls(uploadFiles);
 
+        return UploadFileConverter.INSTANCE.toUploadFilesResponse(uploadFilesLocation);
+    }
+
+    @Override
+    public UploadFilesResponse uploadAndGetUrls(List<MultipartFile> multipartFiles, DomainEnum domain)  {
+        multipartFiles.forEach(domain::validateFor);
+
+        UploadFiles uploadFiles = UploadFiles.of(multipartFiles, domain);
+
+        UploadFilesLocation uploadFilesLocation = uploadAndGetUrls(uploadFiles);
         return UploadFileConverter.INSTANCE.toUploadFilesResponse(uploadFilesLocation);
     }
 

--- a/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
+++ b/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
@@ -1,7 +1,5 @@
 package koreatech.in.service;
 
-import static koreatech.in.controller.UploadController.enrichDomainPath;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -87,14 +85,13 @@ public class S3UploadServiceImpl implements UploadService {
     }
 
     @Override
-    public PreSignedUrlResponse generatePreSignedUrl(String domain, PreSignedUrlRequest preSignedUrlRequest) {
+    public PreSignedUrlResponse generatePreSignedUrl(DomainEnum domain, PreSignedUrlRequest preSignedUrlRequest) {
         //todo 파일 업로드와 같이 리팩터링 필요
         UploadFileMetaData uploadFileMetaData = UploadFileConverter.INSTANCE.toUploadFileMetaData(preSignedUrlRequest);
 
-        DomainEnum domainEnum = DomainEnum.mappingFor(domain);
-        domainEnum.validateMetaData(uploadFileMetaData);
+        domain.validateMetaData(uploadFileMetaData);
 
-        UploadFileFullPath uploadFileFullPath = UploadFileFullPath.of(enrichDomainPath(domainEnum.name().toLowerCase()), uploadFileMetaData.getFileName());
+        UploadFileFullPath uploadFileFullPath = UploadFileFullPath.of(domain.enrichDomainPath(), uploadFileMetaData.getFileName());
         PreSignedUrlResult preSignedUrlResult = s3Util.generatePreSignedUrlForPut(bucketName, uploadFileMetaData,
             uploadFileFullPath.unixValue(), new Date());
 

--- a/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
+++ b/src/main/java/koreatech/in/service/S3UploadServiceImpl.java
@@ -35,14 +35,14 @@ public class S3UploadServiceImpl implements UploadService {
     private final S3Util s3Util;
 
     private final String bucketName;
-    private final String domainName;
+    private final String domainUrlPrefix;
 
     @Autowired
     public S3UploadServiceImpl(S3Util s3Util, @Value("${s3.bucket}") String bucketName,
-                               @Value("${s3.custom_domain}") String domainName) {
+                               @Value("${s3.custom_domain}") String domainUrlPrefix) {
         this.s3Util = s3Util;
         this.bucketName = bucketName;
-        this.domainName = domainName;
+        this.domainUrlPrefix = domainUrlPrefix;
     }
 
     @Override
@@ -50,7 +50,7 @@ public class S3UploadServiceImpl implements UploadService {
         UploadFile file = UploadFileConverter.INSTANCE.toUploadFile(uploadFileRequest);
 
         uploadFor(file);
-        UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainName, file);
+        UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainUrlPrefix, file);
 
         return UploadFileConverter.INSTANCE.toUploadFileResponse(uploadFileLocation);
     }
@@ -62,7 +62,7 @@ public class S3UploadServiceImpl implements UploadService {
         UploadFile file = UploadFile.of(multipartFile, domain);
         uploadFor(file);
 
-        UploadFileLocation uploadFileLocation = UploadFileLocation.of(domain.enrichDomainPath(), file);
+        UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainUrlPrefix, file);
         return UploadFileConverter.INSTANCE.toUploadFileResponse(uploadFileLocation);
     }
 
@@ -96,7 +96,7 @@ public class S3UploadServiceImpl implements UploadService {
         PreSignedUrlResult preSignedUrlResult = s3Util.generatePreSignedUrlForPut(bucketName, uploadFileMetaData,
             uploadFileFullPath.unixValue(), new Date());
 
-        UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainName, uploadFileFullPath);
+        UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainUrlPrefix, uploadFileFullPath);
         return UploadFileConverter.INSTANCE.toPreSignedUrlResponse(preSignedUrlResult, uploadFileLocation);
     }
 
@@ -105,7 +105,7 @@ public class S3UploadServiceImpl implements UploadService {
 
         for (UploadFile file : uploadFiles.getUploadFiles()) {
             uploadFor(file);
-            UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainName, file);
+            UploadFileLocation uploadFileLocation = UploadFileLocation.of(domainUrlPrefix, file);
 
             uploadFilesLocation.append(uploadFileLocation);
         }

--- a/src/main/java/koreatech/in/service/UploadService.java
+++ b/src/main/java/koreatech/in/service/UploadService.java
@@ -1,5 +1,10 @@
 package koreatech.in.service;
 
+import java.io.IOException;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import koreatech.in.domain.Upload.DomainEnum;
 import koreatech.in.dto.normal.upload.request.PreSignedUrlRequest;
 import koreatech.in.dto.normal.upload.request.UploadFileRequest;
 import koreatech.in.dto.normal.upload.request.UploadFilesRequest;
@@ -9,6 +14,8 @@ import koreatech.in.dto.normal.upload.response.UploadFilesResponse;
 
 public interface UploadService {
     UploadFileResponse uploadAndGetUrl(UploadFileRequest uploadFileRequest);
+
+    UploadFileResponse  uploadAndGetUrl(MultipartFile multipartFile, DomainEnum domain) throws IOException;
 
     UploadFilesResponse uploadAndGetUrls(UploadFilesRequest uploadFilesRequest);
 

--- a/src/main/java/koreatech/in/service/UploadService.java
+++ b/src/main/java/koreatech/in/service/UploadService.java
@@ -20,5 +20,5 @@ public interface UploadService {
 
     UploadFilesResponse uploadAndGetUrlsForAdmin(List<MultipartFile> multipartFiles, DomainEnum domain);
 
-    PreSignedUrlResponse generatePreSignedUrl(String domain, PreSignedUrlRequest preSignedUrlRequest);
+    PreSignedUrlResponse generatePreSignedUrl(DomainEnum domain, PreSignedUrlRequest preSignedUrlRequest);
 }

--- a/src/main/java/koreatech/in/service/UploadService.java
+++ b/src/main/java/koreatech/in/service/UploadService.java
@@ -1,6 +1,7 @@
 package koreatech.in.service;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,6 +19,8 @@ public interface UploadService {
     UploadFileResponse  uploadAndGetUrl(MultipartFile multipartFile, DomainEnum domain) throws IOException;
 
     UploadFilesResponse uploadAndGetUrls(UploadFilesRequest uploadFilesRequest);
+
+    UploadFilesResponse uploadAndGetUrls(List<MultipartFile> multipartFiles, DomainEnum domain);
 
     PreSignedUrlResponse generatePreSignedUrl(String domain, PreSignedUrlRequest preSignedUrlRequest);
 

--- a/src/main/java/koreatech/in/service/UploadService.java
+++ b/src/main/java/koreatech/in/service/UploadService.java
@@ -7,21 +7,18 @@ import org.springframework.web.multipart.MultipartFile;
 
 import koreatech.in.domain.Upload.DomainEnum;
 import koreatech.in.dto.normal.upload.request.PreSignedUrlRequest;
-import koreatech.in.dto.normal.upload.request.UploadFileRequest;
-import koreatech.in.dto.normal.upload.request.UploadFilesRequest;
 import koreatech.in.dto.normal.upload.response.PreSignedUrlResponse;
 import koreatech.in.dto.normal.upload.response.UploadFileResponse;
 import koreatech.in.dto.normal.upload.response.UploadFilesResponse;
 
 public interface UploadService {
-    UploadFileResponse uploadAndGetUrl(UploadFileRequest uploadFileRequest);
-
     UploadFileResponse  uploadAndGetUrl(MultipartFile multipartFile, DomainEnum domain) throws IOException;
 
-    UploadFilesResponse uploadAndGetUrls(UploadFilesRequest uploadFilesRequest);
+    UploadFileResponse uploadAndGetUrlForAdmin(MultipartFile multipartFile, DomainEnum domain) throws IOException;
 
     UploadFilesResponse uploadAndGetUrls(List<MultipartFile> multipartFiles, DomainEnum domain);
 
-    PreSignedUrlResponse generatePreSignedUrl(String domain, PreSignedUrlRequest preSignedUrlRequest);
+    UploadFilesResponse uploadAndGetUrlsForAdmin(List<MultipartFile> multipartFiles, DomainEnum domain);
 
+    PreSignedUrlResponse generatePreSignedUrl(String domain, PreSignedUrlRequest preSignedUrlRequest);
 }

--- a/src/main/webapp/WEB-INF/root-context.xml
+++ b/src/main/webapp/WEB-INF/root-context.xml
@@ -14,7 +14,7 @@
     <context:component-scan base-package="koreatech.in.repository" />
     <context:component-scan base-package="koreatech.in.aop" />
     <context:component-scan base-package="koreatech.in.util" />
-    <context:component-scan base-package="koreatech.in.converter" />
+    <context:component-scan base-package="koreatech.in.config" />
 
     <!-- Enable @AspectJ annotation support  -->
     <aop:aspectj-autoproxy />

--- a/src/main/webapp/WEB-INF/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/servlet-context.xml
@@ -27,14 +27,6 @@
         </mvc:argument-resolvers>
     </mvc:annotation-driven>
 
-<!--    <bean id="conversionService" class="org.springframework.format.support.FormattingConversionServiceFactoryBean">-->
-<!--        <property name="converters">-->
-<!--            <list>-->
-<!--                <bean class="koreatech.in.converter.DomainEnumConvertor"/>-->
-<!--            </list>-->
-<!--        </property>-->
-<!--    </bean>-->
-
     <bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
         <property name="prefix" value="/WEB-INF/views/"/>
         <property name="suffix" value=".jsp"/>

--- a/src/main/webapp/WEB-INF/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/servlet-context.xml
@@ -12,7 +12,7 @@
     <context:component-scan base-package="koreatech.in.controller"/>
 
 <!--    conversion-service: 컨버터 등록을 위한 빈 자동 등록-->
-    <mvc:annotation-driven>
+    <mvc:annotation-driven conversion-service="conversionService">
         <mvc:message-converters>
             <bean class="org.springframework.http.converter.StringHttpMessageConverter">
                 <property name="supportedMediaTypes">
@@ -26,6 +26,14 @@
             <bean class="koreatech.in.argumentresolver.UserArgumentResolver"/>
         </mvc:argument-resolvers>
     </mvc:annotation-driven>
+
+<!--    <bean id="conversionService" class="org.springframework.format.support.FormattingConversionServiceFactoryBean">-->
+<!--        <property name="converters">-->
+<!--            <list>-->
+<!--                <bean class="koreatech.in.converter.DomainEnumConvertor"/>-->
+<!--            </list>-->
+<!--        </property>-->
+<!--    </bean>-->
 
     <bean class="org.springframework.web.servlet.view.InternalResourceViewResolver">
         <property name="prefix" value="/WEB-INF/views/"/>


### PR DESCRIPTION
## ▶ Request
### Content
#296
### as-is
- String으로  domain을 받고 `DomainEnum`으로 변환 및 검증 로직을 컨트롤러에서 수행함.
### to-be
- Converter를 이용하여 자동 변환하도록 수정
- Service에서 검증하도록 수정
### 범위
- 기존 업로드 API 4개 (단일, 복합 업로드 여부와 일반, 어드민 여부에 따라 총 4개)
- PreSigned Url API 1개
### 변경 사유
- `DomainEnum`, `Multifile` 모두 DTO가 아닌 도메인으로 취급해야 한다고 판단함.
- 파일과 관련된 로직은 논리적인 검증이므로 서비스에서 검증하는 것이 맞다고 판단함.

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지

## 📸 API Document ScreenShot

## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] 기존 API들이 동일하게(동일한 결과, 동일한 URL 응답) 동작함을 확인
