### PR TITLE
Fix: 기타 정보가 비어있더라도 예외처리되지 않도록 수정

### DIFF
--- a/src/main/java/koreatech/in/dto/admin/shop/request/CreateShopRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/shop/request/CreateShopRequest.java
@@ -1,17 +1,25 @@
 package koreatech.in.dto.admin.shop.request;
 
+import static koreatech.in.exception.ExceptionInformation.*;
+
+import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import koreatech.in.exception.BaseException;
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.Valid;
-import javax.validation.constraints.*;
-import java.time.DayOfWeek;
-import java.util.*;
-
-import static koreatech.in.exception.ExceptionInformation.*;
 
 @Getter @Setter
 @ApiModel("AdminCreateShopRequest")
@@ -51,9 +59,9 @@ public class CreateShopRequest {
                               "- null일 경우 0으로 저장됨", example = "1000")
     private Integer delivery_price = 0;
 
-    @Size(min = 1, max = 50, message = "기타정보의 길이는 1자 이상 50자 이하입니다.")
+    @Size(max = 50, message = "기타정보의 길이는 50자 이하입니다.")
     @ApiModelProperty(notes = "기타정보 \n" +
-                              "- 1자 이상 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
+                              "- 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
     private String description;
 
     @NotNull(message = "배달 가능 여부는 필수입니다.")

--- a/src/main/java/koreatech/in/dto/admin/shop/request/UpdateShopRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/shop/request/UpdateShopRequest.java
@@ -1,20 +1,25 @@
 package koreatech.in.dto.admin.shop.request;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-import koreatech.in.exception.BaseException;
-import lombok.Getter;
-import lombok.Setter;
+import static koreatech.in.exception.ExceptionInformation.*;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
 import java.time.DayOfWeek;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static koreatech.in.exception.ExceptionInformation.*;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import koreatech.in.exception.BaseException;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter @Setter
 @ApiModel("AdminUpdateShopRequest")
@@ -54,9 +59,9 @@ public class UpdateShopRequest {
                               "- null일 경우 0으로 저장됨", example = "1000")
     private Integer delivery_price = 0;
 
-    @Size(min = 1, max = 50, message = "기타정보의 길이는 1자 이상 50자 이하입니다.")
+    @Size(max = 50, message = "기타정보의 길이는 50자 이하입니다.")
     @ApiModelProperty(notes = "기타정보 \n" +
-                              "- 1자 이상 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
+                              "- 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
     private String description;
 
     @NotNull(message = "배달 가능 여부는 필수입니다.")

--- a/src/main/java/koreatech/in/dto/normal/shop/request/CreateShopRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/request/CreateShopRequest.java
@@ -59,9 +59,9 @@ public class CreateShopRequest {
             "- null일 경우 0으로 저장됨", example = "1000")
     private Integer delivery_price = 0;
 
-    @Size(min = 1, max = 50, message = "기타정보의 길이는 1자 이상 50자 이하입니다.")
+    @Size(max = 50, message = "기타정보의 길이는 50자 이하입니다.")
     @ApiModelProperty(notes = "기타정보 \n" +
-            "- 1자 이상 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
+            "- 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
     private String description;
 
     @NotNull(message = "배달 가능 여부는 필수입니다.")

--- a/src/main/java/koreatech/in/dto/normal/shop/request/UpdateShopRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/request/UpdateShopRequest.java
@@ -1,20 +1,25 @@
 package koreatech.in.dto.normal.shop.request;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-import koreatech.in.exception.BaseException;
-import lombok.Getter;
-import lombok.Setter;
+import static koreatech.in.exception.ExceptionInformation.*;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
 import java.time.DayOfWeek;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static koreatech.in.exception.ExceptionInformation.*;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import koreatech.in.exception.BaseException;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter @Setter
 public class UpdateShopRequest {
@@ -53,9 +58,9 @@ public class UpdateShopRequest {
                               "- null일 경우 0으로 저장됨", example = "1000")
     private Integer delivery_price = 0;
 
-    @Size(min = 1, max = 50, message = "기타정보의 길이는 1자 이상 50자 이하입니다.")
+    @Size(max = 50, message = "기타정보의 길이는 50자 이하입니다.")
     @ApiModelProperty(notes = "기타정보 \n" +
-                              "- 1자 이상 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
+                              "- 50자 이하", example = "이번주 전 메뉴 10% 할인 이벤트합니다.")
     private String description;
 
     @NotNull(message = "배달 가능 여부는 필수입니다.")


### PR DESCRIPTION
## ▶ Request
### Content
#299
### as-is
- description에 빈 문자열이 들어온다면 예외처리가 됨.
### to-be
- description에 빈 문자열이 들어오더라도 예외처리가 되지 않도록, 어노테이션 검증을 수정

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot
![image](https://github.com/BCSDLab/KOIN_API/assets/71889359/9ca3e9aa-c387-4922-acb6-fcf00b82477c)


## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] 상점 생성시, `description: ""`도 처리
