### PR TITLE
Feature: 어노테이션 기반 XSS 필터링 기능 추가

### DIFF
--- a/src/main/java/koreatech/in/annotation/XssFilter.java
+++ b/src/main/java/koreatech/in/annotation/XssFilter.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.PARAMETER})
+@Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface XssFilter {
 }

--- a/src/main/java/koreatech/in/annotation/XssFilter.java
+++ b/src/main/java/koreatech/in/annotation/XssFilter.java
@@ -1,0 +1,11 @@
+package koreatech.in.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface XssFilter {
+}

--- a/src/main/java/koreatech/in/aop/XssPrevent.java
+++ b/src/main/java/koreatech/in/aop/XssPrevent.java
@@ -1,0 +1,70 @@
+package koreatech.in.aop;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import koreatech.in.annotation.XssFilter;
+import koreatech.in.exception.BaseException;
+import koreatech.in.exception.ExceptionInformation;
+import koreatech.in.util.StringXssChecker;
+
+@Component
+@Aspect
+public class XssPrevent {
+    private static final Set<Class> requiredAnnotations = new LinkedHashSet<>(Arrays.asList(RequestBody.class, XssFilter.class));
+
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.ResponseBody) "
+        + "&& within(@org.springframework.stereotype.Controller *)")
+    public void atResponseBodyAnnotation() {
+    }
+
+    @Around("atResponseBodyAnnotation()")
+    public Object sendSlackHookingOnCrashForAdmin(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object[] arguments = proceedingJoinPoint.getArgs();
+        Annotation[][] argumentsAnnotations = getArgumentsAnnotations(proceedingJoinPoint);
+
+        filterArgumentsByAnnotation(arguments, argumentsAnnotations, requiredAnnotations);
+
+        return proceedingJoinPoint.proceed(arguments);
+    }
+
+    private Annotation[][] getArgumentsAnnotations(ProceedingJoinPoint proceedingJoinPoint) {
+        return ((MethodSignature)proceedingJoinPoint.getSignature()).getMethod().getParameterAnnotations();
+    }
+    
+    private void filterArgumentsByAnnotation(Object[] arguments, Annotation[][] argumentsAnnotations,
+        Collection<Class> requiredAnnotations) {
+        IntStream.range(0, arguments.length)
+            .filter(index -> containRequiredAnnotations(argumentsAnnotations[index], requiredAnnotations))
+            .forEach(index -> filter(index, arguments));
+    }
+
+    private boolean containRequiredAnnotations(Annotation[] argumentAnnotations, Collection<Class> necessaryAnnotations) {
+        return Arrays.stream(argumentAnnotations)
+            .map(Annotation::annotationType)
+            .collect(Collectors.toSet())
+            .containsAll(necessaryAnnotations);
+    }
+
+    private void filter(int index, Object[] arguments) {
+        try {
+            arguments[index] = StringXssChecker.xssCheck(arguments[index], arguments[index].getClass().newInstance());
+        } catch (Exception e) {
+            throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
+        }
+    }
+
+}

--- a/src/main/java/koreatech/in/aop/XssPrevent.java
+++ b/src/main/java/koreatech/in/aop/XssPrevent.java
@@ -1,10 +1,6 @@
 package koreatech.in.aop;
 
-import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.lang.reflect.Parameter;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -14,54 +10,29 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import koreatech.in.annotation.XssFilter;
-import koreatech.in.exception.BaseException;
-import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.util.StringXssChecker;
 
 @Component
 @Aspect
 public class XssPrevent {
-    private static final List<Class<? extends Annotation>> requiredAnnotations = Arrays.asList(RequestBody.class, XssFilter.class);
+    private static final Class<RequestBody> requiredAnnotation = RequestBody.class;
 
-    @Pointcut("@annotation(org.springframework.web.bind.annotation.ResponseBody) "
+    @Pointcut("@annotation(koreatech.in.annotation.XssFilter) "
         + "&& within(@org.springframework.stereotype.Controller *)")
-    public void atResponseBodyAnnotation() {
+    public void atControllerXssFilterAnnotation() {
     }
 
-    @Around("atResponseBodyAnnotation()")
-    public Object sendSlackHookingOnCrashForAdmin(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+    @Around("atControllerXssFilterAnnotation()")
+    public Object filterRequestBody(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         Object[] arguments = proceedingJoinPoint.getArgs();
-        Annotation[][] argumentsAnnotations = getArgumentsAnnotations(proceedingJoinPoint);
+        Parameter[] parameters = ((MethodSignature)proceedingJoinPoint.getSignature()).getMethod().getParameters();
 
-        filterArgumentsByAnnotation(arguments, argumentsAnnotations);
+        for (int i = 0; i < arguments.length; i++) {
+            if(parameters[i].isAnnotationPresent(requiredAnnotation)) {
+                arguments[i] = StringXssChecker.xssCheck(arguments[i], arguments[i].getClass().newInstance());
+            }
+        }
 
         return proceedingJoinPoint.proceed(arguments);
     }
-
-    private Annotation[][] getArgumentsAnnotations(ProceedingJoinPoint proceedingJoinPoint) {
-        return ((MethodSignature)proceedingJoinPoint.getSignature()).getMethod().getParameterAnnotations();
-    }
-    
-    private void filterArgumentsByAnnotation(Object[] arguments, Annotation[][] argumentsAnnotations) {
-        IntStream.range(0, arguments.length)
-            .filter(index -> containRequiredAnnotations(argumentsAnnotations[index]))
-            .forEach(index -> filter(index, arguments));
-    }
-
-    private boolean containRequiredAnnotations(Annotation[] argumentAnnotations) {
-        return Arrays.stream(argumentAnnotations)
-            .map(Annotation::annotationType)
-            .collect(Collectors.toSet())
-            .containsAll(requiredAnnotations);
-    }
-
-    private void filter(int index, Object[] arguments) {
-        try {
-            arguments[index] = StringXssChecker.xssCheck(arguments[index], arguments[index].getClass().newInstance());
-        } catch (Exception e) {
-            throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
-        }
-    }
-
 }

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -1,5 +1,17 @@
 package koreatech.in.controller;
 
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -7,7 +19,6 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
-import javax.validation.Valid;
 import koreatech.in.annotation.Auth;
 import koreatech.in.annotation.Auth.Authority;
 import koreatech.in.annotation.Auth.Role;
@@ -29,16 +40,6 @@ import koreatech.in.exception.BaseException;
 import koreatech.in.exception.ExceptionInformation;
 import koreatech.in.service.OwnerService;
 import koreatech.in.util.StringXssChecker;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 @Api(tags = "(Normal) Owner", description = "사장님")
 @Auth(role = Role.OWNER, authority = Authority.SHOP)

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -168,8 +168,9 @@ public class OwnerController {
     @AuthExcept
     @RequestMapping(value = "/owners/verification/email", method = RequestMethod.POST)
     @ParamValid
+    @XssFilter
     public @ResponseBody
-    ResponseEntity<EmptyResponse> verifyEmail(@RequestBody @Valid @XssFilter VerifyEmailRequest request,
+    ResponseEntity<EmptyResponse> verifyEmail(@RequestBody @Valid VerifyEmailRequest request,
                                               BindingResult bindingResult) {
         ownerService.requestVerification(request);
         return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -25,6 +25,7 @@ import koreatech.in.annotation.Auth.Role;
 import koreatech.in.annotation.AuthExcept;
 import koreatech.in.annotation.Login;
 import koreatech.in.annotation.ParamValid;
+import koreatech.in.annotation.XssFilter;
 import koreatech.in.domain.User.User;
 import koreatech.in.dto.EmptyResponse;
 import koreatech.in.dto.ExceptionResponse;
@@ -168,14 +169,8 @@ public class OwnerController {
     @RequestMapping(value = "/owners/verification/email", method = RequestMethod.POST)
     @ParamValid
     public @ResponseBody
-    ResponseEntity<EmptyResponse> verifyEmail(@RequestBody @Valid VerifyEmailRequest request,
+    ResponseEntity<EmptyResponse> verifyEmail(@RequestBody @Valid @XssFilter VerifyEmailRequest request,
                                               BindingResult bindingResult) {
-        try {
-            request = StringXssChecker.xssCheck(request, request.getClass().newInstance());
-        } catch (Exception exception) {
-            throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
-        }
-
         ownerService.requestVerification(request);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyEmailRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/user/owner/request/VerifyEmailRequest.java
@@ -1,8 +1,9 @@
 package koreatech.in.dto.normal.user.owner.request;
 
-import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 


### PR DESCRIPTION
## ▶ Request
### Content
#302
### as-is
```
ResponseEntity<EmptyResponse> verifyEmail(@RequestBody @Valid VerifyEmailRequest request,
                                              BindingResult bindingResult) {
        try {
            request = StringXssChecker.xssCheck(request, request.getClass().newInstance());
        } catch (Exception exception) {
            throw new BaseException(ExceptionInformation.REQUEST_DATA_INVALID);
        }
```

와 같이 try-catch문을 통해 xss 필터링을 처리함.
### to-be
```
ResponseEntity<EmptyResponse> verifyEmail(@RequestBody @Valid @XssFilter VerifyEmailRequest request,
                                              BindingResult bindingResult) {
        ownerService.requestVerification(request);
        return new ResponseEntity<>(HttpStatus.OK);
    }
```
와 같이 `@XssFilter`의 추가만으로 필터링을 처리함.
(별도 어노테이션 부착없이도 가능하나, 기존 필터링 방법과 호환성을 위해 추가함.)

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지

## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] XSS 필터링이 잘 동작함을 확인
