### PR TITLE
Bugfix: 임시토큰에 대한 조건문에서 함수를 종료시킬 수 있도록 수정한다.

### DIFF
--- a/src/main/java/koreatech/in/interceptor/AuthInterceptor.java
+++ b/src/main/java/koreatech/in/interceptor/AuthInterceptor.java
@@ -1,13 +1,21 @@
 package koreatech.in.interceptor;
 
 import static koreatech.in.argumentresolver.UserArgumentResolver.USER_OBJECT_ATTRIBUTE;
-import static koreatech.in.exception.ExceptionInformation.BAD_ACCESS;
-import static koreatech.in.exception.ExceptionInformation.FORBIDDEN;
-import static koreatech.in.exception.ExceptionInformation.TOKEN_EXPIRED;
+import static koreatech.in.exception.ExceptionInformation.*;
 
 import java.lang.reflect.Method;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
 import koreatech.in.annotation.ApiOff;
 import koreatech.in.annotation.Auth;
 import koreatech.in.annotation.AuthExcept;
@@ -18,13 +26,6 @@ import koreatech.in.exception.BaseException;
 import koreatech.in.service.AccessJwtValidator;
 import koreatech.in.util.HttpHeaderValue;
 import koreatech.in.util.HttpHeaderValueAttacher;
-import org.apache.http.HttpHeaders;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.method.HandlerMethod;
-import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 public class AuthInterceptor extends HandlerInterceptorAdapter {
     @Autowired
@@ -92,6 +93,8 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
             if (accessJwtValidator.isExpiredToken(accessToken)) {
                 throw new BaseException(TOKEN_EXPIRED);
             }
+
+            return true;
         }
 
         User user = accessJwtValidator.validateAndGetUserFromAccessToken(accessToken);


### PR DESCRIPTION
## ▶ Request
### Content
#304 
### as-is
- 임시토큰을 처리하는 조건문에서 임시토큰을 검증한 이후로도 함수가 종료되지 않는다.
- 따라서, (종료되지 않았기에 이후에 있는 로직들에서) 사용자ID를 가지고 있지 않는 임시 토큰에서 사용자ID를 추출하려 하여 권한 에러가 발생한다.
### to-be
- 임시토큰을 처리하는 조건문에서 정상적으로 임시토큰 검증이 되었다면 함수를 종료하도록 한다.
![image](https://github.com/BCSDLab/KOIN_API/assets/71889359/41d9db67-18b2-4d45-8625-b2b73808572f)


## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot


## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] 임시토큰을 획득한 이후 임시토큰을 활용하는 API(사장님-파일업로드)를 임시토큰으로 이용할 수 있다.
