### PR TITLE
refactor: 상점 반환값이 비어있는 경우 기본값 설정

### DIFF
--- a/src/main/java/koreatech/in/mapstruct/normal/shop/ShopConverter.java
+++ b/src/main/java/koreatech/in/mapstruct/normal/shop/ShopConverter.java
@@ -11,8 +11,10 @@ import org.mapstruct.factory.Mappers;
 
 @Mapper
 public interface ShopConverter {
+
     ShopConverter INSTANCE = Mappers.getMapper(ShopConverter.class);
 
+    @Mapping(target = "description", defaultValue = "-")
     ShopResponse toShopResponse(ShopProfile shopProfile);
 
     @Mapping(target = "category_ids", expression = "java(shopProfile.getShopCategoryIds())")


### PR DESCRIPTION
## ▶ Request
### Content

- #308 

### as-is

ShopResponse 파싱되는 과정에서 결과값이 null 인 상황이 존재함.

### to-be

mapstruct에 `@Mapping(target = "description", defaultValue = "-")` 어노테이션 옵션을 추가해 null일 경우 기본값인 `"-"`를 추가하도록 수정

빌드 시 생성되는 구현체 `ShopConverterImpl` 참고
<img width="654" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/49794401/41676ea1-1562-4b2e-ab7b-ec6640a6e60a">


## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지