### PR TITLE
refactor: 상점 생성 시 메뉴 카테고리 생성

### DIFF
--- a/src/main/java/koreatech/in/repository/ShopMapper.java
+++ b/src/main/java/koreatech/in/repository/ShopMapper.java
@@ -93,4 +93,6 @@ public interface ShopMapper {
     ShopMenu getMenuById(@Param("id") Integer id);
 
     void deleteMenuById(@Param("id") Integer id);
+
+    void createMenuCategories(@Param("menuCategories") List<ShopMenuCategory> menuCategories);
 }

--- a/src/main/resources/mapper/normal/ShopMapper.xml
+++ b/src/main/resources/mapper/normal/ShopMapper.xml
@@ -759,4 +759,18 @@
             <id property="id" column="shop_menu_categories.id"/>
         </collection>
     </resultMap>
+
+    <insert id="createMenuCategories" parameterType="list">
+      INSERT INTO `koin`.`shop_menu_categories` (
+      `shop_id`,
+      `name`
+      )
+      VALUES
+      <foreach collection="menuCategories" item="item" separator=",">
+        (
+        #{item.shop_id},
+        #{item.name}
+        )
+      </foreach>
+    </insert>
 </mapper>


### PR DESCRIPTION
## ▶ Request
### Content

- #310 

### as-is

Owner가 상점 생성 시 기본 메뉴 카테고리를 생성하지 않음.

### to-be

Owner가 상점 생성 시 "이벤트 메뉴", "대표 메뉴", "사이드 메뉴", "세트 메뉴" 생성

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지