### PR TITLE
refactor: 인증코드 최소 길이 6자리로 설정

### DIFF
--- a/src/main/java/koreatech/in/util/RandomGenerator.java
+++ b/src/main/java/koreatech/in/util/RandomGenerator.java
@@ -12,6 +12,6 @@ public class RandomGenerator {
     }
 
     public static CertificationCode getCertificationCode() {
-        return CertificationCode.from(String.format("%03d", getCertificationCodeNumber()));
+        return CertificationCode.from(String.format("%06d", getCertificationCodeNumber()));
     }
 }


### PR DESCRIPTION
## ▶ Request
### Content

- close #321 

### as-is

이메일 인증번호의 자리수가 최소 3자리로 설정되어있었습니다.

### to-be

이메일 인증번호의 자리수를 최소 6자리로 변경했습니다.

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지

## 참고사항

코드에 ThreadLocalRandom 메소드가 사용된 부분을 보고 해당 메소드를 사용한 이유에 대해 정리해봤습니다.
동시성 이슈를 간접적으로 맛볼 수 있는 이슈였네요

- [Random 함수와 동시성](https://velog.io/@junho5336/Random-%ED%95%A8%EC%88%98%EC%99%80-%EB%8F%99%EC%8B%9C%EC%84%B1)