### PR TITLE
refactor: 상점 생성 시 전체 카테고리를 기본적으로 가지도록 수정

### DIFF
--- a/src/main/java/koreatech/in/dto/admin/shop/request/CreateShopRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/shop/request/CreateShopRequest.java
@@ -90,6 +90,10 @@ public class CreateShopRequest {
                               "- 최대 10개")
     private List<String> image_urls = new ArrayList<>();
 
+    public void addToAllCategory() {
+        this.category_ids.add(1);
+    }
+
     @Getter @Setter
     @ApiModel("Open_2")
     public static class Open {

--- a/src/main/java/koreatech/in/dto/normal/shop/request/CreateShopRequest.java
+++ b/src/main/java/koreatech/in/dto/normal/shop/request/CreateShopRequest.java
@@ -91,6 +91,10 @@ public class CreateShopRequest {
             "- 최대 10개")
     private List<String> image_urls = new ArrayList<>();
 
+    public void addToAllCategory() {
+        this.category_ids.add(1);
+    }
+
     @Getter @Setter
     @ApiModel("Open_7")
     public static class Open {

--- a/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerShopServiceImpl.java
@@ -84,6 +84,7 @@ public class OwnerShopServiceImpl implements OwnerShopService {
         List<ShopOpen> shopOpens = generateShopOpens(request.getOpen(), shop.getId());
         shopMapper.createShopOpens(shopOpens);
 
+        request.addToAllCategory();
         shopCategoriesExist(request.getCategory_ids());
         List<ShopCategoryMap> shopCategoryMaps = generateShopCategoryMaps(shop.getId(), request.getCategory_ids());
         shopMapper.createShopCategoryMaps(shopCategoryMaps);

--- a/src/main/java/koreatech/in/service/admin/AdminShopServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminShopServiceImpl.java
@@ -151,6 +151,7 @@ public class AdminShopServiceImpl implements AdminShopService {
 
 
         // ======= shop_category_map 테이블 =======
+        request.addToAllCategory();
         List<Integer> categoryIds = request.getCategory_ids();
 
         checkShopCategoriesExistInDatabase(categoryIds);


### PR DESCRIPTION
## ▶ Request
### Content
 - #320 
### as-is
조회 시 category=1(전체 카테고리) 이 기본적으로 검색조건에 들어가 있습니다. 
<img src="https://github.com/BCSDLab/KOIN_API/assets/106418303/467807c9-fd8f-4cd4-bd84-18848a78e9a8" width=400px></img>

### to-be
상점을 생성할 때 상점  category에 1이 기본적으로 들어가도록 수정하였습니다.

코드 수정한 곳
- (Admin) POST /admin/shops
  - service & DTO
- (Normal) POST /owner/shops
  - service & DTO

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지

## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] Normal과 Admin에서 카테고리 1 (전체 카테고리)를 제외한 카테고리로 상점을 생성했을 때 shop_category_map에 카테고리 1도 함께 들어가는지 테스트
