### PR TITLE
Refactor : 사장님 회원가입시, Shops_id가 보이지 않는 현상

### DIFF
--- a/src/main/java/koreatech/in/controller/OwnerController.java
+++ b/src/main/java/koreatech/in/controller/OwnerController.java
@@ -214,7 +214,8 @@ public class OwnerController {
                     code = 409,
                     message = "- 인증이 되지 않은 이메일일 경우 (code: 101012)"
                             + "\n\n- 이미 누군가 사용중인 이메일일 경우 (code: 101013)"
-                            + "\n\n- 이미 누군가 사용중인 사업자등록번호일 경우 (code: 101021)",
+                            + "\n\n- 이미 누군가 사용중인 사업자등록번호일 경우 (code: 101021)"
+                            + "\n\n- 이미 상점에 사장님 ID가 존재할 경우 (code: 101023)",
                     response = ExceptionResponse.class),
             @ApiResponse(
                     code = 410,

--- a/src/main/java/koreatech/in/controller/admin/AdminUserController.java
+++ b/src/main/java/koreatech/in/controller/admin/AdminUserController.java
@@ -154,9 +154,8 @@ public class AdminUserController {
     })
     @RequestMapping(value = "/admin/owner/{id}/authed", method = RequestMethod.PUT)
     public @ResponseBody
-    ResponseEntity<EmptyResponse> allowOwnerPermission(@ApiParam(value = "ownerId", required = true) @PathVariable("id") Integer ownerId,
-                                                       @ApiParam(value = "shopId") @RequestParam(value = "shopId", required = false) Integer shopId) throws Exception {
-        adminUserService.allowOwnerPermission(ownerId, shopId);
+    ResponseEntity<EmptyResponse> allowOwnerPermission(@ApiParam(value = "ownerId", required = true) @PathVariable("id") Integer ownerId) throws Exception {
+        adminUserService.allowOwnerPermission(ownerId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -39,6 +39,7 @@ public enum ExceptionInformation {
     GENDER_INVALID("유효한 성별이 아닙니다.", 101020, HttpStatus.UNPROCESSABLE_ENTITY),
     COMPANY_REGISTRATION_NUMBER_DUPLICATE("이미 존재하는 사업자 번호입니다.", 101021, HttpStatus.CONFLICT),
     NOT_EXIST_EMAIL("존재하지 않는 이메일입니다.", 101022, HttpStatus.NOT_FOUND),
+    OWNER_ID_FOR_SHOP_DUPLICATED("상점에 이미 사장님 ID가 존재합니다.", 101023, HttpStatus.CONFLICT),
 
 
 

--- a/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/RedisOwnerMapper.java
@@ -68,4 +68,8 @@ public class RedisOwnerMapper {
     public void removeRedisFrom(EmailAddress emailAddress, RedisOwnerKeyPrefix redisOwnerKeyPrefix) {
         stringRedisUtilObj.deleteData(redisOwnerKeyPrefix.getKey(emailAddress.getEmailAddress()));
     }
+
+    public void removeRedisFrom(String ownerKey) {
+        stringRedisUtilObj.deleteData(ownerKey);
+    }
 }

--- a/src/main/java/koreatech/in/repository/user/OwnerMapper.java
+++ b/src/main/java/koreatech/in/repository/user/OwnerMapper.java
@@ -32,4 +32,6 @@ public interface OwnerMapper {
     void deleteOwnerAttachmentsLogically(OwnerAttachments ownerAttachments);
 
     boolean isCompanyRegistrationNumberExist(String companyRegistrationNumber);
+
+    boolean isOwnerIdExistForShopId(int id);
 }

--- a/src/main/java/koreatech/in/service/OwnerServiceImpl.java
+++ b/src/main/java/koreatech/in/service/OwnerServiceImpl.java
@@ -164,6 +164,7 @@ public class OwnerServiceImpl implements OwnerService {
 
         validateEmailUniqueness(ownerEmailAddress);
         validateCompanyRegistrationNumberUniqueness(owner.getCompany_registration_number());
+        validateOwnerIdUniqueness(ownerRegisterRequest.getShopId());
         redisOwnerMapper.validateOwner(ownerEmailAddress, ownerAuthPrefix);
 
         encodePassword(owner);
@@ -269,6 +270,12 @@ public class OwnerServiceImpl implements OwnerService {
     private void validateCompanyRegistrationNumberUniqueness(String companyRegistrationNumber) {
         if (ownerMapper.isCompanyRegistrationNumberExist(companyRegistrationNumber)) {
             throw new BaseException(ExceptionInformation.COMPANY_REGISTRATION_NUMBER_DUPLICATE);
+        }
+    }
+
+    private void validateOwnerIdUniqueness(int id) {
+        if (ownerMapper.isOwnerIdExistForShopId(id)) {
+            throw new BaseException(ExceptionInformation.OWNER_ID_FOR_SHOP_DUPLICATED);
         }
     }
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserService.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserService.java
@@ -52,7 +52,7 @@ public interface AdminUserService {
 
     Map<String, Object> getPermissionListForAdmin(int page, int limit) throws Exception;
 
-    void allowOwnerPermission(Integer ownerId, Integer shopId);
+    void allowOwnerPermission(Integer ownerId);
 
     OwnerResponse getOwner(int ownerId);
 

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -57,6 +57,7 @@ import koreatech.in.mapstruct.admin.user.StudentConverter;
 import koreatech.in.mapstruct.admin.user.UserConverter;
 import koreatech.in.repository.AuthenticationMapper;
 import koreatech.in.repository.AuthorityMapper;
+import koreatech.in.repository.RedisOwnerMapper;
 import koreatech.in.repository.admin.AdminShopMapper;
 import koreatech.in.repository.admin.AdminUserMapper;
 import koreatech.in.repository.user.StudentMapper;
@@ -106,6 +107,9 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Autowired
     private StringRedisUtilObj stringRedisUtilObj;
+
+    @Autowired
+    private RedisOwnerMapper redisOwnerMapper;
 
     @Override
     public LoginResponse login(LoginRequest request) throws Exception {
@@ -211,7 +215,7 @@ public class AdminUserServiceImpl implements AdminUserService {
 
     @Override
     @Transactional
-    public void allowOwnerPermission(Integer ownerId, Integer shopId) {
+    public void allowOwnerPermission(Integer ownerId) {
         User user = Optional.ofNullable(adminUserMapper.getUserById(ownerId)).orElseThrow(() -> new BaseException(INQUIRED_USER_NOT_FOUND));
 
         if (!user.isOwner()) {
@@ -220,11 +224,26 @@ public class AdminUserServiceImpl implements AdminUserService {
         if (user.isAuthenticated()) {
             throw new BaseException(AUTHENTICATED_USER);
         }
+        Integer shopId=getShopIdFromRedis(ownerId);
         if (shopId != null) {
             updateShopOwnerId(ownerId, shopId);
         }
         adminUserMapper.updateOwnerAuthorById(ownerId);
         adminUserMapper.updateOwnerGrantShopByOwnerId(ownerId);
+        redisOwnerMapper.removeRedisFrom(getKeyForRedis(ownerId));
+    }
+
+    private Integer getShopIdFromRedis(Integer ownerId) {
+        OwnerShop ownerShop;
+        try {
+            ownerShop = (OwnerShop) stringRedisUtilObj.getDataAsString(getKeyForRedis(ownerId), OwnerShop.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        if (ownerShop != null) {
+            return ownerShop.getShop_id();
+        }
+        return null;
     }
 
     private void updateShopOwnerId(Integer ownerId, Integer shopId) {

--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -224,7 +224,7 @@ public class AdminUserServiceImpl implements AdminUserService {
         if (user.isAuthenticated()) {
             throw new BaseException(AUTHENTICATED_USER);
         }
-        Integer shopId=getShopIdFromRedis(ownerId);
+        Integer shopId = getShopIdFromRedis(ownerId);
         if (shopId != null) {
             updateShopOwnerId(ownerId, shopId);
         }
@@ -236,7 +236,7 @@ public class AdminUserServiceImpl implements AdminUserService {
     private Integer getShopIdFromRedis(Integer ownerId) {
         OwnerShop ownerShop;
         try {
-            ownerShop = (OwnerShop) stringRedisUtilObj.getDataAsString(getKeyForRedis(ownerId), OwnerShop.class);
+            ownerShop = (OwnerShop)stringRedisUtilObj.getDataAsString(getKeyForRedis(ownerId), OwnerShop.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -590,13 +590,13 @@ public class AdminUserServiceImpl implements AdminUserService {
 
         shopsId = adminUserMapper.getShopsIdByOwnerId(id);
 
-        if (shopsId == null || shopsId.isEmpty()){
+        if (shopsId == null || shopsId.isEmpty()) {
             try {
-                ownerShop = (OwnerShop) stringRedisUtilObj.getDataAsString(getKeyForRedis(id), OwnerShop.class);
+                ownerShop = (OwnerShop)stringRedisUtilObj.getDataAsString(getKeyForRedis(id), OwnerShop.class);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            shopsId= Collections.singletonList(ownerShop.getShop_id());
+            shopsId = Collections.singletonList(ownerShop.getShop_id());
         }
 
         return shopsId;

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -122,9 +122,11 @@
     </select>
 
     <select id="isOwnerIdExistForShopId" resultType="boolean">
-        SELECT COUNT(*) > 0
+        SELECT EXISTS (
+        SELECT 1
         FROM koin.shops
         WHERE id = #{id} AND owner_id IS NOT NULL
+        )
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/normal/OwnerMapper.xml
+++ b/src/main/resources/mapper/normal/OwnerMapper.xml
@@ -121,4 +121,10 @@
         WHERE company_registration_number = #{companyRegistrationNumber}
     </select>
 
+    <select id="isOwnerIdExistForShopId" resultType="boolean">
+        SELECT COUNT(*) > 0
+        FROM koin.shops
+        WHERE id = #{id} AND owner_id IS NOT NULL
+    </select>
+
 </mapper>


### PR DESCRIPTION
## ▶ Request
### Content
#315 
### as-is
사장님이 회원가입시에는 Shops_id를 기입하였으나, 어드민페이지(프론트)에서 사장님을 승인할때 Shops_id가 확인되지 않는 현상이 생겼다.
이유는 사장님을 승인하지 않은 경우 Shop의정보는 DB에 존재하지 않아 조회가 불가능 하기 때문이다
### to-be
Redis에서 임시로 정보를 저장하였다가 승인이 끝나면 삭제하는 방향으로 해결을 하였다.

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot
![image](https://github.com/BCSDLab/KOIN_API/assets/79901434/8d4eb942-cada-46e2-aa43-202a341ae0c5)
ownerID가 존재할 경우 중복가입 방지
<img width="239" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/79901434/7e9b1022-1f7c-433c-9578-ea6b46c801ee">
미승인 사장님의 정보조회시 shops_id 보이지 않는 현상 해결
<img width="694" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/79901434/e519471e-4db0-43b6-bc4a-8de9c4c6dcf2">
사장님 권한 허용시, Shop_id의 파라미터의 불필요로 제거

## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] `상점 데이터베이스에 ownerID가 이미 존재할 경우 중복가입 방지 `
- [x] `어드민 페이지에서 사장님승인 목적으로 인한 조회시, shop_ID가 생략될 경우 Redis에서 정보 조회 추가 `
- [x] `어드민에서 사장님 허용시, DB에서 Shop_ID를 가져올 이유가 없기에 ShopID파라미터 생략 후 Redis에서 조회`
- [x] `어드민에서 사장님 허용시, Redis의 key/value 삭제`

