### PR TITLE
Refactor : 어드민에서 shops_id가 없는 사장님 조회시 NPE가 나오는 현상

### DIFF
--- a/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
+++ b/src/main/java/koreatech/in/service/admin/AdminUserServiceImpl.java
@@ -596,7 +596,11 @@ public class AdminUserServiceImpl implements AdminUserService {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            shopsId = Collections.singletonList(ownerShop.getShop_id());
+            if (ownerShop != null) {
+                shopsId = Collections.singletonList(ownerShop.getShop_id());
+            } else {
+                shopsId = Collections.emptyList();
+            }
         }
 
         return shopsId;


### PR DESCRIPTION
## ▶ Request
### Content
![image](https://github.com/BCSDLab/KOIN_API/assets/79901434/8cc7734f-5ebb-4fea-89c6-cf12eb6ea175)

### as-is
shops_id가 없는 사장님을 조회시 500에러 NPE를 뱉어낸다
### to-be
shops_id가 없는 경우에 null을 반환하도록 처리한다

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot

![shops_id가 null인 경우](https://github.com/BCSDLab/KOIN_API/assets/79901434/fe01dbd7-b29f-40d2-b93a-a3b817778464)
![shops_id가 null이 아닌 경우](https://github.com/BCSDLab/KOIN_API/assets/79901434/3ddf0b07-7a74-4251-bc3a-5ceb74b718d0)

## 🧪 Te
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] `shops_id가 있는 경우`
- [x] `shops_id가 없는 경우`
