### PR TITLE
Refactor/미사용 테이블 참조하는 로직 제거

### DIFF
--- a/src/main/java/koreatech/in/service/LandServiceImpl.java
+++ b/src/main/java/koreatech/in/service/LandServiceImpl.java
@@ -138,23 +138,10 @@ public class LandServiceImpl implements LandService {
         if (land == null)
             throw new NotFoundException(new ErrorMessage("There is no item", 0));
 
-        List<LandComment> landComments = landMapper.getLandCommentList(id);
-
-        for (LandComment itemComment:landComments) {
-            if (user != null && (user.getId().equals(itemComment.getUser_id()) || (user.getAuthority() != null && user.getAuthority().getGrant_land()))) {
-                itemComment.setGrantEdit(true);
-                itemComment.setGrantDelete(true);
-            }
-            else {
-                itemComment.setGrantEdit(false);
-                itemComment.setGrantDelete(false);
-            }
-        }
         Map<String, Object> convertLand = domainToMap(land);
 
         convertLand.replace("image_urls", JsonConstructor.parseJsonArrayWithOnlyString(land.getImage_urls()));
         convertLand.put("permalink", URLEncoder.encode(land.getInternal_name(), "UTF-8"));
-        convertLand.put("comments", landComments);
 
         return convertLand;
     }


### PR DESCRIPTION
## ▶ Request
### Content
#328
### as-is
Deprecated 된 테이블 land-comments를 참조하는 로직이 LandServiceImpl에 존재. 
### to-be
LandServiceImpl에서 land-comments참조하는 로직 제거

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지

## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] `로컬 테스트, 기능 정상 동작`
