### PR TITLE
Fix: 메뉴 옵션 정보가 null인 경우 예외처리

### DIFF
--- a/src/main/java/koreatech/in/dto/admin/shop/request/UpdateShopMenuRequest.java
+++ b/src/main/java/koreatech/in/dto/admin/shop/request/UpdateShopMenuRequest.java
@@ -1,20 +1,26 @@
 package koreatech.in.dto.admin.shop.request;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-import koreatech.in.exception.BaseException;
-import lombok.Getter;
-import lombok.Setter;
+import static koreatech.in.exception.ExceptionInformation.DUPLICATE_OPTIONS_EXIST_IN_MENU;
+import static koreatech.in.exception.ExceptionInformation.PRICE_OF_MENU_IS_REQUIRED;
 
-import javax.validation.Valid;
-import javax.validation.constraints.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static koreatech.in.exception.ExceptionInformation.*;
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import koreatech.in.exception.BaseException;
+import lombok.Getter;
+import lombok.Setter;
 
 @Getter @Setter
 public class UpdateShopMenuRequest {
@@ -124,6 +130,9 @@ public class UpdateShopMenuRequest {
 
     @JsonIgnore
     private boolean isOptionPricesEmpty() {
+        if (this.option_prices == null) {
+            return true;
+        }
         return this.option_prices.isEmpty();
     }
 


### PR DESCRIPTION
## ▶ Request
### Content
<!-- 이슈 번호가 있으면 적어주세요. e.g. #13 -->

[관련 메시지](https://bcsdlab.slack.com/archives/CE3MQCQNA/p1706926001557609?thread_ts=1706612150.110219&cid=CE3MQCQNA)

### as-is
option_prices는 List로 입력받고 `isEmpty()`에 대해서만 예외처리를 진행하고 있음.
따라서 요청으로 빈 배열이 아니라 null 값이 들어올 경우 NullpointerException이 발생함.

### to-be
null 검사 구문을 추가하여 위 문제 해결

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot


## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] `option_prices`에 null 값이 들어오더라도 정상적으로 로직이 수행된다.
