### PR TITLE
Fix: owner_attachments 테이블에 created_at 칼럼 추가

### DIFF
--- a/src/main/resources/db/migration/V74__add_column_owner_attachments_table_created_at.sql
+++ b/src/main/resources/db/migration/V74__add_column_owner_attachments_table_created_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `owner_attachments` ADD `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER `is_deleted`


### PR DESCRIPTION
## ▶ Request
### Content
<!-- 이슈 번호가 있으면 적어주세요. e.g. #13 -->

### as-is
<img src="https://github.com/BCSDLab/KOIN_API/assets/21010656/032c008a-027c-4185-9467-911935a5b1ad" width=400px/> <br/>
<img src="https://github.com/BCSDLab/KOIN_API/assets/21010656/c2e0a46b-2d2e-4492-b76c-d06a2fb29b84" width=600px/>

현재 `owner_attachments` 테이블에는 `created_at`이 누락되어 있다.

### to-be
<img src="https://github.com/BCSDLab/KOIN_API/assets/21010656/393ed6a5-941c-44f4-9ffc-c9bedf0a8024" width=500px/> <br/>
<img src="https://github.com/BCSDLab/KOIN_API/assets/21010656/a36ff9f5-7158-436c-8457-3ab439a69030)" width=600px/>

`created_at` 칼럼을 추가하는 flyway 구문을 추가했다.

### 궁금한 부분

1. 일반 tomcat 실행으로는 flyway가 DB에 반영되지 않고 `flyway:migrate` 명령을 실행해야만 반영됩니다.  지금까지 DB 마이그레이션은 이렇게 진행해왔던 것인지, 아니면 제가 설정을 못한 부분이 있는 것인지 궁금합니다.
2. `created_at` 칼럼 추가 시 현재 시각을 기입하도록 되어있는데, 이 점 때문에 기존 값들은 `updated_at`보다 `created_at` 에 더 늦은 시각이 기입됩니다. 이 점이 괜찮을지 궁금합니다.
<img src="https://github.com/BCSDLab/KOIN_API/assets/21010656/172514f5-8a6d-47ff-b20a-e0127536e7b0" width=500px/> <br/>


## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지


## 📸 API Document ScreenShot


## 🧪 Test
<!-- 본인이 **확실하게** 테스트한 내용들을 짧게 적어주세요. -->
- [x] 칼럼이 정상적으로 추가됨을 확인했다.
