### PR TITLE
refactor: 파일의 url path에 https 추가

### DIFF
--- a/src/main/java/koreatech/in/domain/Upload/UploadFileLocation.java
+++ b/src/main/java/koreatech/in/domain/Upload/UploadFileLocation.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 @Getter
 public class UploadFileLocation {
 
+    private static final String HTTPS_PROTOCOL = "https://";
+
     private final String fileUrl;
     private final String fileName;
 
@@ -14,11 +16,13 @@ public class UploadFileLocation {
     }
 
     public static UploadFileLocation of(String domainName, UploadFile uploadFile) {
-        return new UploadFileLocation(domainName + UploadFileFullPath.SLASH +  uploadFile.getFullPath(), uploadFile.getFileName());
+        return new UploadFileLocation(HTTPS_PROTOCOL + domainName + UploadFileFullPath.SLASH + uploadFile.getFullPath(),
+                uploadFile.getFileName());
     }
 
     public static UploadFileLocation of(String domainName, UploadFileFullPath uploadFileFullPath) {
-        return new UploadFileLocation(domainName + UploadFileFullPath.SLASH +  uploadFileFullPath.unixValue(),
+        return new UploadFileLocation(
+                HTTPS_PROTOCOL + domainName + UploadFileFullPath.SLASH + uploadFileFullPath.unixValue(),
                 uploadFileFullPath.getFileFullName());
     }
 

--- a/src/main/java/koreatech/in/dto/normal/upload/response/PreSignedUrlResponse.java
+++ b/src/main/java/koreatech/in/dto/normal/upload/response/PreSignedUrlResponse.java
@@ -32,7 +32,7 @@ public class PreSignedUrlResponse {
     private final Date expirationDate;
 
     @ApiModelProperty(notes = "업로드한 파일을 가져올 때 사용하는 url",
-            example = "static.koreatech.in/2023/09/01/uuid/example.png",
+            example = "https://static.koreatech.in/2023/09/01/uuid/example.png",
             required = true
     )
     private final String fileUrl;


### PR DESCRIPTION
## ▶ Request

- #340 

### Content

프로토콜이 존재하지 않아 presigned url 실행 결과로 반환된 값을 즉시 사용하지 못함.

### as-is

static.koreatech.in/filepath

### to-be

https://static.koreatech.in/filepath

## ✅ Check List
- [x] 의도치 않은 변경이 일어나지 않았는지.
  - 실수로 라이브러리(`pom.xml`) 변경이 일어나지 않았는지
  - 병합시 컴파일 & 런타임 에러가 발생하지 않는지
  - 기존 클라이언트와의 호환성 고려가 잘 이루어졌는지
- [x] 작성한 코드가 프로젝트에 반영됨을 명심하였는지
  - 타인도 알아보고 변경할 수 있는 코드를 작성하였는지
  - 코드 & 커밋 컨벤션을 준수하였는지
  - (필요한) 문서화가 진행되었는지
- [x] (기능 추가의 경우) 클라이언트의 입장에 대한 충분한 고려가 이루어졌는지
  - 클라이언트 측과 협의가 된 내용인 경우
  - 클라이언트의 요구사항을 잘 반영하는지
  - API 문서에 논리적인 오류 & 가시성이 떨어지는 내용이 없는지

