### PR TITLE
fix: presigned url 에만 https 프로토콜 적용되도록 수정

### DIFF
--- a/src/main/java/koreatech/in/domain/Upload/UploadFileLocation.java
+++ b/src/main/java/koreatech/in/domain/Upload/UploadFileLocation.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 @Getter
 public class UploadFileLocation {
 
-    private static final String HTTPS_PROTOCOL = "https://";
-
     private final String fileUrl;
     private final String fileName;
 
@@ -16,13 +14,12 @@ public class UploadFileLocation {
     }
 
     public static UploadFileLocation of(String domainName, UploadFile uploadFile) {
-        return new UploadFileLocation(HTTPS_PROTOCOL + domainName + UploadFileFullPath.SLASH + uploadFile.getFullPath(),
+        return new UploadFileLocation(domainName + UploadFileFullPath.SLASH + uploadFile.getFullPath(),
                 uploadFile.getFileName());
     }
 
     public static UploadFileLocation of(String domainName, UploadFileFullPath uploadFileFullPath) {
-        return new UploadFileLocation(
-                HTTPS_PROTOCOL + domainName + UploadFileFullPath.SLASH + uploadFileFullPath.unixValue(),
+        return new UploadFileLocation(domainName + UploadFileFullPath.SLASH + uploadFileFullPath.unixValue(),
                 uploadFileFullPath.getFileFullName());
     }
 


### PR DESCRIPTION
안드로이드의 presignedUrl의 경로에 대응하기위해 `https://` 프로토콜 path를 추가해줌
이로 인해 기존에 사용하던 file upload에 대해서도 `https://`가 추가됨

프론트엔드에서 해당 파일 업로드 API가 얼마나 남았는지 확인하기 어렵다고 하여 기존에 사용하던 방식에 대한 file upload API는 기존 방식으로 유지하는 방향으로 fix한다.
![image](https://github.com/BCSDLab/KOIN_API/assets/49794401/5b5303d5-b3e5-4036-979c-b50bc17930a5)
