### PR TITLE
refactor: 사장님이 승인이 되지 않은 경우 "가입이 승인되지 않았습니다." 메시지로 반환

### DIFF
--- a/src/main/java/koreatech/in/exception/ExceptionInformation.java
+++ b/src/main/java/koreatech/in/exception/ExceptionInformation.java
@@ -13,6 +13,7 @@ public enum ExceptionInformation {
     PAGE_NOT_FOUND("유효하지 않은 페이지입니다.", 100002, HttpStatus.NOT_FOUND),
     FORBIDDEN("권한이 없습니다.", 100003, HttpStatus.FORBIDDEN),
     TOKEN_EXPIRED("토큰의 유효시간이 만료되었습니다. 다시 로그인해주세요.", 100004, HttpStatus.UNAUTHORIZED),
+    USER_NOT_AUTHORIZED("가입이 승인되지 않았습니다.", 100005, HttpStatus.FORBIDDEN),
 //    ACCESS_TOKEN_CHANGED("토큰이 변경되었습니다. 다시 로그인해주세요.", 100005, HttpStatus.UNAUTHORIZED),
 
     // ======= 코인 회원 (학생, 사장님) =======


### PR DESCRIPTION
# 어떤 이슈인가요?

사장님이 회원가입을 수행하고 로그인을 시도했을 때 권한이 없다는 오류가 발생하여 회원가입을 재시도하는 상황이 발생

UX 측면에서 다른 페이지를 보여줘야할 것으로 판단하여 사장님이 미인증상태에서 로그인을 시도하는 경우 
`가입이 승인되지 않았습니다.` 라는 메시지를 반환하도록 
분기를 구분함
<img width="408" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/49794401/3b68c02c-880a-46ab-8971-313567bb1f69">
