### PR TITLE
fix: 쿼리 컬럼명 변경

### DIFF
--- a/src/main/resources/mapper/normal/UserMapper.xml
+++ b/src/main/resources/mapper/normal/UserMapper.xml
@@ -338,7 +338,7 @@
             WHERE `user_id` = #{user.id};
 
             DELETE
-            FROM `koin`.`owner_shop_attachment`
+            FROM `koin`.`owner_attachments`
             WHERE `owner_id` = #{user.id};
         </if>
 


### PR DESCRIPTION
# 작업내용

<img width="722" alt="image" src="https://github.com/BCSDLab/KOIN_API/assets/49794401/3010ca1b-49be-4f09-96bc-ada8cbd7e219">

사장님 탈퇴 시 쿼리에서 잘못된 컬럼을 참조하고있는 것을 발견했습니다.